### PR TITLE
Restore libxml error handling state in AJAX callbacks

### DIFF
--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -98,10 +98,11 @@ function blc_ajax_edit_link_callback() {
     }
 
     // Chargement du contenu dans DOMDocument
-    libxml_use_internal_errors(true);
+    $previous = libxml_use_internal_errors(true);
     $dom = new DOMDocument();
     $dom->loadHTML(mb_convert_encoding($post->post_content, 'HTML-ENTITIES', 'UTF-8'), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
     libxml_clear_errors();
+    libxml_use_internal_errors($previous);
 
     // Recherche et modification de la balise <a> ciblée
     $xpath = new DOMXPath($dom);
@@ -146,10 +147,11 @@ function blc_ajax_unlink_callback() {
     }
 
     // Chargement du contenu dans DOMDocument
-    libxml_use_internal_errors(true);
+    $previous = libxml_use_internal_errors(true);
     $dom = new DOMDocument();
     $dom->loadHTML(mb_convert_encoding($post->post_content, 'HTML-ENTITIES', 'UTF-8'), LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
     libxml_clear_errors();
+    libxml_use_internal_errors($previous);
 
     // Recherche de la balise <a> à retirer
     $xpath = new DOMXPath($dom);

--- a/tests/BlcAjaxCallbacksTest.php
+++ b/tests/BlcAjaxCallbacksTest.php
@@ -84,8 +84,16 @@ class BlcAjaxCallbacksTest extends TestCase
             throw new \Exception('success');
         });
 
-        $this->expectExceptionMessage('success');
-        blc_ajax_edit_link_callback();
+        $initial = libxml_use_internal_errors();
+
+        try {
+            blc_ajax_edit_link_callback();
+            $this->fail('wp_send_json_success was not called');
+        } catch (\Exception $e) {
+            $this->assertSame('success', $e->getMessage());
+        }
+
+        $this->assertSame($initial, libxml_use_internal_errors());
     }
 
     public function test_unlink_denied_for_user_without_permission(): void
@@ -131,7 +139,15 @@ class BlcAjaxCallbacksTest extends TestCase
             throw new \Exception('success');
         });
 
-        $this->expectExceptionMessage('success');
-        blc_ajax_unlink_callback();
+        $initial = libxml_use_internal_errors();
+
+        try {
+            blc_ajax_unlink_callback();
+            $this->fail('wp_send_json_success was not called');
+        } catch (\Exception $e) {
+            $this->assertSame('success', $e->getMessage());
+        }
+
+        $this->assertSame($initial, libxml_use_internal_errors());
     }
 }


### PR DESCRIPTION
## Summary
- Preserve original libxml error handling when editing or unlinking links
- Add tests ensuring libxml error handling state is restored after callbacks

## Testing
- `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68c7c5ab35bc832eb4e9c8c0f36ec9ba