### PR TITLE
Remove unused options from uninstall script

### DIFF
--- a/liens-morts-detector-jlg/uninstall.php
+++ b/liens-morts-detector-jlg/uninstall.php
@@ -6,9 +6,8 @@ if (!defined('WP_UNINSTALL_PLUGIN')) {
 }
 
 // Liste de toutes les options que notre plugin a créées dans la base de données
+// (les liens et images brisés sont stockés dans une table dédiée)
 $options_to_delete = [
-    'blc_broken_links',
-    'blc_broken_images',
     'blc_last_check_time',
     'blc_frequency',
     'blc_rest_start_hour',


### PR DESCRIPTION
## Summary
- remove non-existent options from uninstall cleanup
- document that broken links and images are stored in custom table

## Testing
- `composer install`
- `./vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68c7c5ad18e4832e8fdcd02408ff85e6