### PR TITLE
Slash post content before updating post

### DIFF
--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -118,7 +118,7 @@ function blc_ajax_edit_link_callback() {
 
     // Enregistrement du contenu mis à jour
     $new_content = $dom->saveHTML();
-    wp_update_post(['ID' => $post_id, 'post_content' => $new_content]);
+    wp_update_post(['ID' => $post_id, 'post_content' => wp_slash($new_content)]);
 
     // Supprimer le lien de la table dédiée
     global $wpdb;
@@ -171,7 +171,7 @@ function blc_ajax_unlink_callback() {
 
     // Enregistrement du contenu mis à jour
     $new_content = $dom->saveHTML();
-    wp_update_post(['ID' => $post_id, 'post_content' => $new_content]);
+    wp_update_post(['ID' => $post_id, 'post_content' => wp_slash($new_content)]);
 
     // Supprimer le lien de la table dédiée
     global $wpdb;


### PR DESCRIPTION
## Summary
- Use `wp_slash` on post content before calling `wp_update_post` in AJAX callbacks

## Testing
- `php -l liens-morts-detector-jlg/liens-morts-detector-jlg.php`
- `./vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68c80e7ea930832ea5ae4d91d781d9c2