### PR TITLE
Validate AJAX parameters for edit and unlink

### DIFF
--- a/tests/BlcAjaxCallbacksTest.php
+++ b/tests/BlcAjaxCallbacksTest.php
@@ -42,6 +42,94 @@ class BlcAjaxCallbacksTest extends TestCase
         $wpdb = null;
     }
 
+    public function editLinkMissingParamProvider(): array
+    {
+        return [
+            'missing post_id' => [
+                ['old_url' => 'http://old.com', 'new_url' => 'http://new.com'],
+                'post_id',
+            ],
+            'empty post_id' => [
+                ['post_id' => '   ', 'old_url' => 'http://old.com', 'new_url' => 'http://new.com'],
+                'post_id',
+            ],
+            'missing old_url' => [
+                ['post_id' => 5, 'new_url' => 'http://new.com'],
+                'old_url',
+            ],
+            'empty old_url' => [
+                ['post_id' => 5, 'old_url' => '   ', 'new_url' => 'http://new.com'],
+                'old_url',
+            ],
+            'missing new_url' => [
+                ['post_id' => 5, 'old_url' => 'http://old.com'],
+                'new_url',
+            ],
+            'empty new_url' => [
+                ['post_id' => 5, 'old_url' => 'http://old.com', 'new_url' => '   '],
+                'new_url',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider editLinkMissingParamProvider
+     */
+    public function test_edit_link_returns_error_when_required_param_is_missing(array $post_data, string $missing_param): void
+    {
+        $_POST = $post_data;
+
+        Functions\expect('check_ajax_referer')->once()->with('blc_edit_link_nonce')->andReturn(true);
+
+        $expected_message = sprintf('Le paramètre requis "%s" est manquant ou vide.', $missing_param);
+        Functions\expect('wp_send_json_error')->once()->with(['message' => $expected_message])->andReturnUsing(function () {
+            throw new \Exception('error');
+        });
+
+        $this->expectExceptionMessage('error');
+        blc_ajax_edit_link_callback();
+    }
+
+    public function unlinkMissingParamProvider(): array
+    {
+        return [
+            'missing post_id' => [
+                ['url_to_unlink' => 'http://old.com'],
+                'post_id',
+            ],
+            'empty post_id' => [
+                ['post_id' => '   ', 'url_to_unlink' => 'http://old.com'],
+                'post_id',
+            ],
+            'missing url_to_unlink' => [
+                ['post_id' => 6],
+                'url_to_unlink',
+            ],
+            'empty url_to_unlink' => [
+                ['post_id' => 6, 'url_to_unlink' => '   '],
+                'url_to_unlink',
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider unlinkMissingParamProvider
+     */
+    public function test_unlink_returns_error_when_required_param_is_missing(array $post_data, string $missing_param): void
+    {
+        $_POST = $post_data;
+
+        Functions\expect('check_ajax_referer')->once()->with('blc_unlink_nonce')->andReturn(true);
+
+        $expected_message = sprintf('Le paramètre requis "%s" est manquant ou vide.', $missing_param);
+        Functions\expect('wp_send_json_error')->once()->with(['message' => $expected_message])->andReturnUsing(function () {
+            throw new \Exception('error');
+        });
+
+        $this->expectExceptionMessage('error');
+        blc_ajax_unlink_callback();
+    }
+
     public function test_edit_link_denied_for_user_without_permission(): void
     {
         $_POST['post_id'] = 1;


### PR DESCRIPTION
## Summary
- add a shared validator that ensures required AJAX parameters are present and non-empty before processing edit or unlink requests
- invoke the validator within the edit and unlink callbacks to return explicit JSON errors when data is missing
- extend the PHPUnit suite with data providers covering missing and empty parameter scenarios for both callbacks

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68c8487b57bc832e90c2572ab82526df