### PR TITLE
Respect WordPress timezone for scheduled scans

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-activation.php
+++ b/liens-morts-detector-jlg/includes/blc-activation.php
@@ -146,7 +146,7 @@ function blc_activation() {
     // On vérifie si une tâche est déjà planifiée pour éviter les doublons
     if (!wp_next_scheduled('blc_check_links')) {
         // Planifie l'événement : quand commencer (maintenant), à quelle fréquence, et quelle action exécuter
-        wp_schedule_event(time(), $frequency, 'blc_check_links');
+        wp_schedule_event(current_time('timestamp'), $frequency, 'blc_check_links');
     }
 }
 

--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -24,7 +24,7 @@ function blc_dashboard_links_page() {
         check_admin_referer('blc_manual_check_nonce');
         $is_full = isset($_POST['blc_full_scan']);
         wp_clear_scheduled_hook('blc_check_batch');
-        wp_schedule_single_event(time(), 'blc_check_batch', array(0, $is_full));
+        wp_schedule_single_event(current_time('timestamp'), 'blc_check_batch', array(0, $is_full));
         echo '<div class="notice notice-success is-dismissible"><p>La vérification des liens a été programmée et s\'exécute en arrière-plan.</p></div>';
     }
 
@@ -87,7 +87,7 @@ function blc_dashboard_images_page() {
     if (isset($_POST['blc_manual_image_check'])) {
         check_admin_referer('blc_manual_image_check_nonce');
         wp_clear_scheduled_hook('blc_check_image_batch');
-        wp_schedule_single_event(time(), 'blc_check_image_batch', array(0, true));
+        wp_schedule_single_event(current_time('timestamp'), 'blc_check_image_batch', array(0, true));
         echo '<div class="notice notice-success is-dismissible"><p>La vérification des images a été programmée et s\'exécute en arrière-plan.</p></div>';
     }
 
@@ -154,7 +154,7 @@ function blc_settings_page() {
         update_option('blc_debug_mode', isset($_POST['blc_debug_mode']));
         $frequency = sanitize_text_field($_POST['blc_frequency']);
         wp_clear_scheduled_hook('blc_check_links');
-        wp_schedule_event(time(), $frequency, 'blc_check_links');
+        wp_schedule_event(current_time('timestamp'), $frequency, 'blc_check_links');
         echo '<div class="notice notice-success is-dismissible"><p>Réglages enregistrés !</p></div>';
     }
 

--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -31,7 +31,7 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
         $load = sys_getloadavg();
         if ($load[0] > 2.0) {
             if ($debug_mode) { error_log("Scan reporté : charge serveur trop élevée (" . $load[0] . ")."); }
-            wp_schedule_single_event(time() + 300, 'blc_check_batch', array($batch, $is_full_scan));
+            wp_schedule_single_event(current_time('timestamp') + 300, 'blc_check_batch', array($batch, $is_full_scan));
             return;
         }
     }
@@ -136,9 +136,9 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
 
     // --- 5. Sauvegarde et planification ---
     if ($query->max_num_pages > ($batch + 1)) {
-        wp_schedule_single_event(time() + $batch_delay_s, 'blc_check_batch', array($batch + 1, $is_full_scan));
+        wp_schedule_single_event(current_time('timestamp') + $batch_delay_s, 'blc_check_batch', array($batch + 1, $is_full_scan));
     } else {
-        update_option('blc_last_check_time', time());
+        update_option('blc_last_check_time', current_time('timestamp'));
     }
 
     if ($debug_mode) { error_log("--- Fin du scan LIENS (Lot #$batch) ---"); }
@@ -197,7 +197,7 @@ function blc_perform_image_check($batch = 0, $is_full_scan = true) { // Une anal
 
     if ($query->max_num_pages > ($batch + 1)) {
         // On utilise un hook de batch différent pour ne pas interférer
-        wp_schedule_single_event(time() + 60, 'blc_check_image_batch', array($batch + 1, true));
+        wp_schedule_single_event(current_time('timestamp') + 60, 'blc_check_image_batch', array($batch + 1, true));
     } else {
         if ($debug_mode) { error_log("--- Scan IMAGES terminé ---"); }
     }


### PR DESCRIPTION
## Summary
- replace direct time() usage with current_time('timestamp') when scheduling link and image scans so WordPress timezone settings are respected

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c85d379c8c832ebc8c84dfe76ac668