### PR TITLE
Secure XPath query for link edits

### DIFF
--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -153,7 +153,10 @@ function blc_ajax_edit_link_callback() {
 
     // Recherche et modification de la balise <a> ciblée
     $xpath = new DOMXPath($dom);
-    $anchors = $xpath->query('//a[@href="' . $old_url . '"]');
+    $escaped_old_url = function_exists('esc_attr')
+        ? esc_attr($old_url)
+        : htmlspecialchars($old_url, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    $anchors = $xpath->query(sprintf('//a[@href="%s"]', $escaped_old_url));
 
     if ($anchors->length === 0) {
         wp_send_json_error(['message' => 'Le lien n\'a pas été trouvé dans le contenu de l\'article.']);


### PR DESCRIPTION
## Summary
- escape the dynamic href value before building the XPath query in the AJAX link edit handler
- provide a non-WordPress fallback so tests can continue to run outside of WP

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68c85d390950832ea268f447cfed7e2e