### PR TITLE
Factorise le chargement du DOM pour les callbacks AJAX

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-utils.php
+++ b/liens-morts-detector-jlg/includes/blc-utils.php
@@ -1,0 +1,50 @@
+<?php
+
+// Sécurité : empêche l'accès direct au fichier
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Charge le contenu HTML d'un article dans un DOMDocument et retourne également un DOMXPath.
+ *
+ * Cette fonction centralise la gestion des erreurs libxml et garantit la restauration de la
+ * configuration précédente de libxml_use_internal_errors().
+ *
+ * @param string $post_content Contenu de l'article.
+ * @return array{dom: DOMDocument, xpath: DOMXPath}|array{error: string} Tableau associatif contenant le DOMDocument et DOMXPath, ou un message d'erreur.
+ */
+function blc_load_dom_from_post($post_content) {
+    $previous = libxml_use_internal_errors(true);
+
+    $dom = new DOMDocument();
+
+    $converted_content = mb_convert_encoding($post_content, 'HTML-ENTITIES', 'UTF-8');
+    if ($converted_content === false) {
+        $converted_content = $post_content;
+    }
+
+    $loaded = $dom->loadHTML($converted_content, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD);
+    $errors = libxml_get_errors();
+
+    libxml_clear_errors();
+    libxml_use_internal_errors($previous);
+
+    if (!$loaded) {
+        $message = 'Impossible de charger le contenu HTML de l\'article.';
+
+        if (!empty($errors)) {
+            $first_error = reset($errors);
+            if ($first_error instanceof \LibXMLError) {
+                $message .= ' ' . trim($first_error->message);
+            }
+        }
+
+        return ['error' => $message];
+    }
+
+    return [
+        'dom' => $dom,
+        'xpath' => new DOMXPath($dom),
+    ];
+}


### PR DESCRIPTION
## Summary
- ajoute l'utilitaire `blc_load_dom_from_post` pour centraliser le chargement du DOM et la remise à zéro de libxml
- remplace les blocs dupliqués dans les callbacks AJAX par cet utilitaire
- enregistre le nouveau fichier utilitaire lors du chargement du plugin

## Testing
- php -d auto_prepend_file=/tmp/current_time_stub.php ./vendor/bin/phpunit --bootstrap vendor/autoload.php tests

------
https://chatgpt.com/codex/tasks/task_e_68c874d7cf60832eb2089e255da802fb