### PR TITLE
Validate URLs in AJAX callbacks

### DIFF
--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -134,8 +134,15 @@ function blc_ajax_edit_link_callback() {
         wp_send_json_error(['message' => 'Permissions insuffisantes.']);
     }
 
-    $old_url = esc_url_raw($params['old_url']);
-    $new_url = esc_url_raw($params['new_url']);
+    $old_url = wp_http_validate_url($params['old_url']);
+    $new_url = wp_http_validate_url($params['new_url']);
+
+    if (!$old_url || !$new_url) {
+        wp_send_json_error(['message' => 'URL invalide.']);
+    }
+
+    $old_url = esc_url_raw($old_url);
+    $new_url = esc_url_raw($new_url);
 
     $post = get_post($post_id);
     if (!$post) {
@@ -192,7 +199,13 @@ function blc_ajax_unlink_callback() {
         wp_send_json_error(['message' => 'Permissions insuffisantes.']);
     }
 
-    $url_to_unlink = esc_url_raw($params['url_to_unlink']);
+    $url_to_unlink = wp_http_validate_url($params['url_to_unlink']);
+
+    if (!$url_to_unlink) {
+        wp_send_json_error(['message' => 'URL invalide.']);
+    }
+
+    $url_to_unlink = esc_url_raw($url_to_unlink);
 
     $post = get_post($post_id);
     if (!$post) {


### PR DESCRIPTION
## Summary
- validate edited link URLs with `wp_http_validate_url` before processing
- reject unlink requests that provide invalid URLs
- return a standardized JSON error message when validation fails

## Testing
- php -l liens-morts-detector-jlg/liens-morts-detector-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68c91ce59944832eba0c026712f6469c