### PR TITLE
Use host comparison for internal image detection

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -229,7 +229,12 @@ function blc_perform_image_check($batch = 0, $is_full_scan = true) { // Une anal
             $image_url = trim(wp_kses_decode_entities($image_node->getAttribute('src')));
             if ($image_url === '') { continue; }
 
-            if (strpos($image_url, $site_url) === false) { continue; }
+            $image_host = parse_url($image_url, PHP_URL_HOST);
+            $site_host  = parse_url($site_url, PHP_URL_HOST);
+
+            if (!empty($image_host) && !empty($site_host) && strcasecmp($image_host, $site_host) !== 0) {
+                continue;
+            }
             $file_path = str_replace($upload_dir_info['baseurl'], $upload_dir_info['basedir'], $image_url);
             if (!file_exists($file_path)) {
                 if ($debug_mode) { error_log("  -> Image Cassée Trouvée : " . $image_url); }


### PR DESCRIPTION
## Summary
- update the image scanning routine to use host comparison instead of raw string matching when identifying internal images

## Testing
- php -l liens-morts-detector-jlg/includes/blc-scanner.php

------
https://chatgpt.com/codex/tasks/task_e_68c91cd4a488832e9b28fc990be0c5df