### PR TITLE
Handle missing mb_convert_encoding in DOM loader

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-utils.php
+++ b/liens-morts-detector-jlg/includes/blc-utils.php
@@ -19,8 +19,12 @@ function blc_load_dom_from_post($post_content) {
 
     $dom = new DOMDocument();
 
-    $converted_content = mb_convert_encoding($post_content, 'HTML-ENTITIES', 'UTF-8');
-    if ($converted_content === false) {
+    if (function_exists('mb_convert_encoding')) {
+        $converted_content = mb_convert_encoding($post_content, 'HTML-ENTITIES', 'UTF-8');
+        if ($converted_content === false) {
+            $converted_content = $post_content;
+        }
+    } else {
         $converted_content = $post_content;
     }
 


### PR DESCRIPTION
## Summary
- guard the DOM loader against missing `mb_convert_encoding`
- fall back to the original post content if conversion is unavailable or fails

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9461124e0832e903b9e4ace40b4b0