### PR TITLE
Handle failures when updating or deleting links

### DIFF
--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -176,12 +176,39 @@ function blc_ajax_edit_link_callback() {
 
     // Enregistrement du contenu mis à jour
     $new_content = $dom->saveHTML();
-    wp_update_post(['ID' => $post_id, 'post_content' => wp_slash($new_content)]);
+    $update_result = wp_update_post([
+        'ID' => $post_id,
+        'post_content' => wp_slash($new_content),
+    ], true);
+
+    if (!$update_result || is_wp_error($update_result)) {
+        $error_message = 'La mise à jour de l\'article a échoué.';
+        if (is_wp_error($update_result)) {
+            $error_message .= ' ' . $update_result->get_error_message();
+        }
+
+        wp_send_json_error(['message' => $error_message]);
+        return;
+    }
 
     // Supprimer le lien de la table dédiée
     global $wpdb;
     $table_name = $wpdb->prefix . 'blc_broken_links';
-    $wpdb->delete($table_name, ['post_id' => $post_id, 'url' => $old_url, 'type' => 'link'], ['%d', '%s', '%s']);
+    $delete_result = $wpdb->delete(
+        $table_name,
+        ['post_id' => $post_id, 'url' => $old_url, 'type' => 'link'],
+        ['%d', '%s', '%s']
+    );
+
+    if (!$delete_result || is_wp_error($delete_result)) {
+        $error_message = 'La suppression du lien dans la base de données a échoué.';
+        if (is_wp_error($delete_result)) {
+            $error_message .= ' ' . $delete_result->get_error_message();
+        }
+
+        wp_send_json_error(['message' => $error_message]);
+        return;
+    }
 
     wp_send_json_success();
 }
@@ -243,12 +270,39 @@ function blc_ajax_unlink_callback() {
 
     // Enregistrement du contenu mis à jour
     $new_content = $dom->saveHTML();
-    wp_update_post(['ID' => $post_id, 'post_content' => wp_slash($new_content)]);
+    $update_result = wp_update_post([
+        'ID' => $post_id,
+        'post_content' => wp_slash($new_content),
+    ], true);
+
+    if (!$update_result || is_wp_error($update_result)) {
+        $error_message = 'La mise à jour de l\'article a échoué.';
+        if (is_wp_error($update_result)) {
+            $error_message .= ' ' . $update_result->get_error_message();
+        }
+
+        wp_send_json_error(['message' => $error_message]);
+        return;
+    }
 
     // Supprimer le lien de la table dédiée
     global $wpdb;
     $table_name = $wpdb->prefix . 'blc_broken_links';
-    $wpdb->delete($table_name, ['post_id' => $post_id, 'url' => $url_to_unlink, 'type' => 'link'], ['%d', '%s', '%s']);
+    $delete_result = $wpdb->delete(
+        $table_name,
+        ['post_id' => $post_id, 'url' => $url_to_unlink, 'type' => 'link'],
+        ['%d', '%s', '%s']
+    );
+
+    if (!$delete_result || is_wp_error($delete_result)) {
+        $error_message = 'La suppression du lien dans la base de données a échoué.';
+        if (is_wp_error($delete_result)) {
+            $error_message .= ' ' . $delete_result->get_error_message();
+        }
+
+        wp_send_json_error(['message' => $error_message]);
+        return;
+    }
 
     wp_send_json_success();
 }


### PR DESCRIPTION
## Summary
- handle failures from `wp_update_post` in the edit and unlink AJAX callbacks and return clear error messages
- surface database deletion errors when removing broken link entries

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c94611f994832e94c14734074df12c