### PR TITLE
Localize admin texts and expose JS messages

### DIFF
--- a/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
+++ b/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
@@ -1,4 +1,9 @@
 jQuery(document).ready(function($) {
+    var messages = window.blcAdminMessages || {};
+    var editPromptMessage = messages.editPromptMessage || "Entrez la nouvelle URL pour :\n%s";
+    var editPromptDefault = messages.editPromptDefault || 'https://';
+    var unlinkConfirmation = messages.unlinkConfirmation || "Êtes-vous sûr de vouloir supprimer ce lien ? Le texte sera conservé.";
+    var errorPrefix = messages.errorPrefix || 'Erreur : ';
 
     /**
      * Gère le clic sur le bouton "Modifier le lien".
@@ -13,7 +18,8 @@ jQuery(document).ready(function($) {
         var nonce = linkElement.data('nonce');
 
         // Affiche une boîte de dialogue pour demander la nouvelle URL
-        var newUrl = prompt("Entrez la nouvelle URL pour :\n" + oldUrl, "https://");
+        var promptMessage = editPromptMessage.replace('%s', oldUrl);
+        var newUrl = prompt(promptMessage, editPromptDefault);
 
         // Si l'utilisateur a entré une nouvelle URL et n'a pas annulé
         if (newUrl && newUrl !== oldUrl) {
@@ -33,7 +39,7 @@ jQuery(document).ready(function($) {
                     linkElement.closest('tr').fadeOut(300, function() { $(this).remove(); });
                 } else {
                     // S'il y a une erreur, on l'affiche et on remet la ligne en état normal
-                    alert("Erreur : " + response.data.message);
+                    alert(errorPrefix + response.data.message);
                     linkElement.closest('tr').css('opacity', 1);
                 }
             });
@@ -52,7 +58,7 @@ jQuery(document).ready(function($) {
         var nonce = linkElement.data('nonce');
 
         // Demande une confirmation avant de supprimer le lien
-        if (confirm("Êtes-vous sûr de vouloir supprimer ce lien ? Le texte sera conservé.")) {
+        if (confirm(unlinkConfirmation)) {
             linkElement.closest('tr').css('opacity', 0.5);
 
             $.post(ajaxurl, {
@@ -64,7 +70,7 @@ jQuery(document).ready(function($) {
                 if (response.success) {
                     linkElement.closest('tr').fadeOut(300, function() { $(this).remove(); });
                 } else {
-                    alert("Erreur : " + response.data.message);
+                    alert(errorPrefix + response.data.message);
                     linkElement.closest('tr').css('opacity', 1);
                 }
             });

--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -9,10 +9,38 @@ if (!defined('ABSPATH')) {
  * Crée le menu principal et les sous-menus pour les rapports et les réglages.
  */
 function blc_add_admin_menu() {
-    add_menu_page('Liens Morts', 'Liens Morts', 'manage_options', 'blc-dashboard', 'blc_dashboard_links_page', 'dashicons-editor-unlink');
-    add_submenu_page('blc-dashboard', 'Liens Cassés', 'Liens Cassés', 'manage_options', 'blc-dashboard', 'blc_dashboard_links_page');
-    add_submenu_page('blc-dashboard', 'Images Cassées', 'Images Cassées', 'manage_options', 'blc-images-dashboard', 'blc_dashboard_images_page');
-    add_submenu_page('blc-dashboard', 'Réglages', 'Réglages', 'manage_options', 'blc-settings', 'blc_settings_page');
+    add_menu_page(
+        __('Liens Morts', 'liens-morts-detector-jlg'),
+        __('Liens Morts', 'liens-morts-detector-jlg'),
+        'manage_options',
+        'blc-dashboard',
+        'blc_dashboard_links_page',
+        'dashicons-editor-unlink'
+    );
+    add_submenu_page(
+        'blc-dashboard',
+        __('Liens Cassés', 'liens-morts-detector-jlg'),
+        __('Liens Cassés', 'liens-morts-detector-jlg'),
+        'manage_options',
+        'blc-dashboard',
+        'blc_dashboard_links_page'
+    );
+    add_submenu_page(
+        'blc-dashboard',
+        __('Images Cassées', 'liens-morts-detector-jlg'),
+        __('Images Cassées', 'liens-morts-detector-jlg'),
+        'manage_options',
+        'blc-images-dashboard',
+        'blc_dashboard_images_page'
+    );
+    add_submenu_page(
+        'blc-dashboard',
+        __('Réglages', 'liens-morts-detector-jlg'),
+        __('Réglages', 'liens-morts-detector-jlg'),
+        'manage_options',
+        'blc-settings',
+        'blc_settings_page'
+    );
 }
 
 /**
@@ -25,7 +53,10 @@ function blc_dashboard_links_page() {
         $is_full = isset($_POST['blc_full_scan']);
         wp_clear_scheduled_hook('blc_check_batch');
         wp_schedule_single_event(current_time('timestamp'), 'blc_check_batch', array(0, $is_full));
-        echo '<div class="notice notice-success is-dismissible"><p>La vérification des liens a été programmée et s\'exécute en arrière-plan.</p></div>';
+        printf(
+            '<div class="notice notice-success is-dismissible"><p>%s</p></div>',
+            esc_html__("La vérification des liens a été programmée et s'exécute en arrière-plan.", 'liens-morts-detector-jlg')
+        );
     }
 
     // Préparation des données et des statistiques pour les liens
@@ -47,29 +78,56 @@ function blc_dashboard_links_page() {
     );
     $last_check_time    = get_option('blc_last_check_time', 0);
     $option_size_kb     = $option_size_bytes / 1024;
-    $size_display       = ($option_size_kb < 1024) ? number_format_i18n($option_size_kb, 2) . ' Ko' : number_format_i18n($option_size_kb / 1024, 2) . ' Mo';
+    $size_display       = ($option_size_kb < 1024)
+        ? sprintf('%s %s', number_format_i18n($option_size_kb, 2), __('Ko', 'liens-morts-detector-jlg'))
+        : sprintf('%s %s', number_format_i18n($option_size_kb / 1024, 2), __('Mo', 'liens-morts-detector-jlg'));
+    $last_check_display = $last_check_time ? date_i18n('j M Y', $last_check_time) : __('Jamais', 'liens-morts-detector-jlg');
 
     $list_table = new BLC_Links_List_Table();
     $list_table->prepare_items();
     ?>
     <div class="wrap">
-        <h1>Rapport des Liens Cassés</h1>
+        <h1><?php esc_html_e('Rapport des Liens Cassés', 'liens-morts-detector-jlg'); ?></h1>
         <div class="blc-stats-box">
-            <div class="blc-stat"><span class="blc-stat-value"><?php echo $broken_links_count; ?></span><span class="blc-stat-label">Liens morts trouvés</span></div>
-            <div class="blc-stat"><span class="blc-stat-value"><?php echo $size_display; ?></span><span class="blc-stat-label">Poids des données</span></div>
-            <div class="blc-stat"><span class="blc-stat-value"><?php echo $last_check_time ? date_i18n('j M Y', $last_check_time) : 'Jamais'; ?></span><span class="blc-stat-label">Dernière analyse</span></div>
+            <div class="blc-stat">
+                <span class="blc-stat-value"><?php echo esc_html($broken_links_count); ?></span>
+                <span class="blc-stat-label"><?php esc_html_e('Liens morts trouvés', 'liens-morts-detector-jlg'); ?></span>
+            </div>
+            <div class="blc-stat">
+                <span class="blc-stat-value"><?php echo esc_html($size_display); ?></span>
+                <span class="blc-stat-label"><?php esc_html_e('Poids des données', 'liens-morts-detector-jlg'); ?></span>
+            </div>
+            <div class="blc-stat">
+                <span class="blc-stat-value"><?php echo esc_html($last_check_display); ?></span>
+                <span class="blc-stat-label"><?php esc_html_e('Dernière analyse', 'liens-morts-detector-jlg'); ?></span>
+            </div>
         </div>
         <form method="post" style="margin-bottom: 20px;">
             <?php wp_nonce_field('blc_manual_check_nonce'); ?>
             <input type="hidden" name="blc_manual_check" value="1">
             <p>
-                <label><input type="checkbox" name="blc_full_scan"> Lancer une <strong>analyse complète</strong> de tous les articles (plus lent)</label><br>
-                <small>Si non cochée, l'analyse ne portera que sur les articles modifiés depuis la dernière exécution.</small>
+                <label>
+                    <input type="checkbox" name="blc_full_scan">
+                    <?php
+                    echo wp_kses(
+                        sprintf(
+                            /* translators: 1: opening strong tag, 2: closing strong tag. */
+                            __('Lancer une %1$sanalyse complète%2$s de tous les articles (plus lent)', 'liens-morts-detector-jlg'),
+                            '<strong>',
+                            '</strong>'
+                        ),
+                        array(
+                            'strong' => array(),
+                        )
+                    );
+                    ?>
+                </label><br>
+                <small><?php esc_html_e('Si non cochée, l\'analyse ne portera que sur les articles modifiés depuis la dernière exécution.', 'liens-morts-detector-jlg'); ?></small>
             </p>
-            <input type="submit" class="button button-primary" value="Lancer la vérification des liens">
+            <input type="submit" class="button button-primary" value="<?php echo esc_attr__('Lancer la vérification des liens', 'liens-morts-detector-jlg'); ?>">
         </form>
         <?php if ($broken_links_count === 0): ?>
-             <p>✅ Aucun lien mort trouvé. Bravo !</p>
+             <p><?php esc_html_e('✅ Aucun lien mort trouvé. Bravo !', 'liens-morts-detector-jlg'); ?></p>
         <?php else: ?>
             <form method="post">
                 <?php $list_table->views(); $list_table->display(); ?>
@@ -88,7 +146,10 @@ function blc_dashboard_images_page() {
         check_admin_referer('blc_manual_image_check_nonce');
         wp_clear_scheduled_hook('blc_check_image_batch');
         wp_schedule_single_event(current_time('timestamp'), 'blc_check_image_batch', array(0, true));
-        echo '<div class="notice notice-success is-dismissible"><p>La vérification des images a été programmée et s\'exécute en arrière-plan.</p></div>';
+        printf(
+            '<div class="notice notice-success is-dismissible"><p>%s</p></div>',
+            esc_html__("La vérification des images a été programmée et s'exécute en arrière-plan.", 'liens-morts-detector-jlg')
+        );
     }
 
     global $wpdb;
@@ -109,26 +170,38 @@ function blc_dashboard_images_page() {
     );
     $last_check_time     = get_option('blc_last_check_time', 0);
     $option_size_kb      = $option_size_bytes / 1024;
-    $size_display        = ($option_size_kb < 1024) ? number_format_i18n($option_size_kb, 2) . ' Ko' : number_format_i18n($option_size_kb / 1024, 2) . ' Mo';
+    $size_display        = ($option_size_kb < 1024)
+        ? sprintf('%s %s', number_format_i18n($option_size_kb, 2), __('Ko', 'liens-morts-detector-jlg'))
+        : sprintf('%s %s', number_format_i18n($option_size_kb / 1024, 2), __('Mo', 'liens-morts-detector-jlg'));
+    $last_check_display  = $last_check_time ? date_i18n('j M Y', $last_check_time) : __('Jamais', 'liens-morts-detector-jlg');
 
     $list_table = new BLC_Images_List_Table();
     $list_table->prepare_items();
     ?>
     <div class="wrap">
-        <h1>Rapport des Images Cassées</h1>
+        <h1><?php esc_html_e('Rapport des Images Cassées', 'liens-morts-detector-jlg'); ?></h1>
         <div class="blc-stats-box">
-             <div class="blc-stat"><span class="blc-stat-value"><?php echo $broken_images_count; ?></span><span class="blc-stat-label">Images cassées trouvées</span></div>
-             <div class="blc-stat"><span class="blc-stat-value"><?php echo $size_display; ?></span><span class="blc-stat-label">Poids des données</span></div>
-             <div class="blc-stat"><span class="blc-stat-value"><?php echo $last_check_time ? date_i18n('j M Y', $last_check_time) : 'Jamais'; ?></span><span class="blc-stat-label">Dernière analyse de liens</span></div>
+             <div class="blc-stat">
+                 <span class="blc-stat-value"><?php echo esc_html($broken_images_count); ?></span>
+                 <span class="blc-stat-label"><?php esc_html_e('Images cassées trouvées', 'liens-morts-detector-jlg'); ?></span>
+             </div>
+             <div class="blc-stat">
+                 <span class="blc-stat-value"><?php echo esc_html($size_display); ?></span>
+                 <span class="blc-stat-label"><?php esc_html_e('Poids des données', 'liens-morts-detector-jlg'); ?></span>
+             </div>
+             <div class="blc-stat">
+                 <span class="blc-stat-value"><?php echo esc_html($last_check_display); ?></span>
+                 <span class="blc-stat-label"><?php esc_html_e('Dernière analyse de liens', 'liens-morts-detector-jlg'); ?></span>
+             </div>
         </div>
         <form method="post" style="margin-bottom: 20px;">
             <?php wp_nonce_field('blc_manual_image_check_nonce'); ?>
             <input type="hidden" name="blc_manual_image_check" value="1">
-            <p>L'analyse des images peut être longue et consommer des ressources. Elle s'exécute en arrière-plan sur l'ensemble du site.</p>
-            <input type="submit" class="button button-primary" value="Lancer l'analyse des images">
+            <p><?php esc_html_e("L'analyse des images peut être longue et consommer des ressources. Elle s'exécute en arrière-plan sur l'ensemble du site.", 'liens-morts-detector-jlg'); ?></p>
+            <input type="submit" class="button button-primary" value="<?php echo esc_attr__("Lancer l'analyse des images", 'liens-morts-detector-jlg'); ?>">
         </form>
         <?php if ($broken_images_count === 0): ?>
-             <p>✅ Aucune image cassée trouvée. Bravo !</p>
+             <p><?php esc_html_e('✅ Aucune image cassée trouvée. Bravo !', 'liens-morts-detector-jlg'); ?></p>
         <?php else: ?>
             <form method="post">
                 <?php $list_table->display(); ?>
@@ -155,7 +228,10 @@ function blc_settings_page() {
         $frequency = sanitize_text_field($_POST['blc_frequency']);
         wp_clear_scheduled_hook('blc_check_links');
         wp_schedule_event(current_time('timestamp'), $frequency, 'blc_check_links');
-        echo '<div class="notice notice-success is-dismissible"><p>Réglages enregistrés !</p></div>';
+        printf(
+            '<div class="notice notice-success is-dismissible"><p>%s</p></div>',
+            esc_html__('Réglages enregistrés !', 'liens-morts-detector-jlg')
+        );
     }
 
     $frequency = get_option('blc_frequency', 'daily');
@@ -168,91 +244,123 @@ function blc_settings_page() {
     $debug_mode = get_option('blc_debug_mode', false);
     ?>
     <div class="wrap">
-        <h1>Réglages des liens morts</h1>
+        <h1><?php esc_html_e('Réglages des liens morts', 'liens-morts-detector-jlg'); ?></h1>
         <form method="post">
             <?php wp_nonce_field('blc_settings_nonce'); ?>
-            <h2>Planification</h2>
+            <h2><?php esc_html_e('Planification', 'liens-morts-detector-jlg'); ?></h2>
             <table class="form-table" role="presentation">
                 <tbody>
                     <tr>
-                        <th scope="row"><label for="blc_frequency">Fréquence de vérification</label></th>
+                        <th scope="row"><label for="blc_frequency"><?php esc_html_e('Fréquence de vérification', 'liens-morts-detector-jlg'); ?></label></th>
                         <td>
                             <select name="blc_frequency" id="blc_frequency">
-                                <option value="daily" <?php selected($frequency, 'daily'); ?>>Quotidienne</option>
-                                <option value="weekly" <?php selected($frequency, 'weekly'); ?>>Hebdomadaire</option>
-                                <option value="monthly" <?php selected($frequency, 'monthly'); ?>>Mensuelle</option>
+                                <option value="daily" <?php selected($frequency, 'daily'); ?>><?php esc_html_e('Quotidienne', 'liens-morts-detector-jlg'); ?></option>
+                                <option value="weekly" <?php selected($frequency, 'weekly'); ?>><?php esc_html_e('Hebdomadaire', 'liens-morts-detector-jlg'); ?></option>
+                                <option value="monthly" <?php selected($frequency, 'monthly'); ?>><?php esc_html_e('Mensuelle', 'liens-morts-detector-jlg'); ?></option>
                             </select>
-                            <p class="description">Fréquence de la vérification automatique des <strong>liens</strong>.</p>
+                            <p class="description">
+                                <?php
+                                echo wp_kses(
+                                    __('Fréquence de la vérification automatique des <strong>liens</strong>.', 'liens-morts-detector-jlg'),
+                                    array(
+                                        'strong' => array(),
+                                    )
+                                );
+                                ?>
+                            </p>
                         </td>
                     </tr>
                     <tr>
-                        <th scope="row"><label for="blc_rest_start_hour">😴 Plage horaire de repos</label></th>
+                        <th scope="row"><label for="blc_rest_start_hour"><?php esc_html_e('😴 Plage horaire de repos', 'liens-morts-detector-jlg'); ?></label></th>
                         <td>
-                            Ne pas lancer de scan entre
+                            <?php esc_html_e('Ne pas lancer de scan entre', 'liens-morts-detector-jlg'); ?>
                             <input type="time" name="blc_rest_start_hour" value="<?php echo esc_attr($rest_start_hour); ?>:00">
-                            et
+                            <?php esc_html_e('et', 'liens-morts-detector-jlg'); ?>
                             <input type="time" name="blc_rest_end_hour" value="<?php echo esc_attr($rest_end_hour); ?>:00">
-                            <p class="description">Le scan automatique des <strong>liens</strong> ne s'exécutera pas durant cette période. (Fuseau horaire de Paris)</p>
+                            <p class="description">
+                                <?php
+                                echo wp_kses(
+                                    __('Le scan automatique des <strong>liens</strong> ne s\'exécutera pas durant cette période. (Fuseau horaire de Paris)', 'liens-morts-detector-jlg'),
+                                    array(
+                                        'strong' => array(),
+                                    )
+                                );
+                                ?>
+                            </p>
                         </td>
                     </tr>
                 </tbody>
             </table>
-            <h2>Performance</h2>
+            <h2><?php esc_html_e('Performance', 'liens-morts-detector-jlg'); ?></h2>
             <table class="form-table" role="presentation">
                  <tbody>
                     <tr>
-                        <th scope="row"><label for="blc_link_delay">⚙️ Délai entre chaque lien</label></th>
+                        <th scope="row"><label for="blc_link_delay"><?php esc_html_e('⚙️ Délai entre chaque lien', 'liens-morts-detector-jlg'); ?></label></th>
                         <td>
-                           <input type="number" name="blc_link_delay" id="blc_link_delay" value="<?php echo esc_attr($link_delay); ?>" min="0" step="50"> ms
-                           <p class="description">Pause après la vérification de chaque URL. (Défaut : 200)</p>
+                           <input type="number" name="blc_link_delay" id="blc_link_delay" value="<?php echo esc_attr($link_delay); ?>" min="0" step="50"> <?php esc_html_e('ms', 'liens-morts-detector-jlg'); ?>
+                           <p class="description"><?php esc_html_e('Pause après la vérification de chaque URL. (Défaut : 200)', 'liens-morts-detector-jlg'); ?></p>
                         </td>
                     </tr>
                      <tr>
-                        <th scope="row"><label for="blc_batch_delay">⚙️ Délai entre chaque lot</label></th>
+                        <th scope="row"><label for="blc_batch_delay"><?php esc_html_e('⚙️ Délai entre chaque lot', 'liens-morts-detector-jlg'); ?></label></th>
                         <td>
-                           <input type="number" name="blc_batch_delay" id="blc_batch_delay" value="<?php echo esc_attr($batch_delay); ?>" min="10" step="10"> secondes
-                           <p class="description">Pause entre chaque groupe de 20 articles analysés. (Défaut : 60)</p>
+                           <input type="number" name="blc_batch_delay" id="blc_batch_delay" value="<?php echo esc_attr($batch_delay); ?>" min="10" step="10"> <?php esc_html_e('secondes', 'liens-morts-detector-jlg'); ?>
+                           <p class="description"><?php esc_html_e('Pause entre chaque groupe de 20 articles analysés. (Défaut : 60)', 'liens-morts-detector-jlg'); ?></p>
                         </td>
                     </tr>
                  </tbody>
             </table>
-            <h2>Méthode d'Analyse</h2>
+            <h2><?php esc_html_e('Méthode d\'Analyse', 'liens-morts-detector-jlg'); ?></h2>
             <table class="form-table" role="presentation">
                  <tbody>
                     <tr>
-                        <th scope="row">Stratégie de vérification</th>
+                        <th scope="row"><?php esc_html_e('Stratégie de vérification', 'liens-morts-detector-jlg'); ?></th>
                         <td>
                             <fieldset>
-                                <label><input type="radio" name="blc_scan_method" value="precise" <?php checked($scan_method, 'precise'); ?>><strong>Précise (recommandé)</strong><p class="description">Simule un navigateur. Réduit les faux positifs, mais est un peu plus lent.</p></label><br>
-                                <label><input type="radio" name="blc_scan_method" value="fast" <?php checked($scan_method, 'fast'); ?>><strong>Rapide</strong><p class="description">Vérification basique. Très léger, mais peut générer des faux positifs.</p></label>
+                                <label>
+                                    <input type="radio" name="blc_scan_method" value="precise" <?php checked($scan_method, 'precise'); ?>>
+                                    <strong><?php esc_html_e('Précise (recommandé)', 'liens-morts-detector-jlg'); ?></strong>
+                                    <p class="description"><?php esc_html_e('Simule un navigateur. Réduit les faux positifs, mais est un peu plus lent.', 'liens-morts-detector-jlg'); ?></p>
+                                </label><br>
+                                <label>
+                                    <input type="radio" name="blc_scan_method" value="fast" <?php checked($scan_method, 'fast'); ?>>
+                                    <strong><?php esc_html_e('Rapide', 'liens-morts-detector-jlg'); ?></strong>
+                                    <p class="description"><?php esc_html_e('Vérification basique. Très léger, mais peut générer des faux positifs.', 'liens-morts-detector-jlg'); ?></p>
+                                </label>
                             </fieldset>
                         </td>
                     </tr>
                     <tr>
-                        <th scope="row"><label for="blc_excluded_domains">Liste d'exclusion</label></th>
+                        <th scope="row"><label for="blc_excluded_domains"><?php esc_html_e('Liste d\'exclusion', 'liens-morts-detector-jlg'); ?></label></th>
                         <td>
                            <textarea name="blc_excluded_domains" id="blc_excluded_domains" rows="5" class="large-text"><?php echo esc_textarea($excluded_domains); ?></textarea>
-                           <p class="description">Domaines à ignorer pendant l'analyse. Un domaine par ligne (ex: amazon.fr).</p>
+                           <p class="description"><?php esc_html_e('Domaines à ignorer pendant l\'analyse. Un domaine par ligne (ex: amazon.fr).', 'liens-morts-detector-jlg'); ?></p>
                         </td>
                     </tr>
                  </tbody>
             </table>
-            <h2>Débogage</h2>
+            <h2><?php esc_html_e('Débogage', 'liens-morts-detector-jlg'); ?></h2>
             <table class="form-table" role="presentation">
                  <tbody>
                     <tr>
-                        <th scope="row">Mode Débogage</th>
+                        <th scope="row"><?php esc_html_e('Mode Débogage', 'liens-morts-detector-jlg'); ?></th>
                         <td>
                            <fieldset>
-                                <label for="blc_debug_mode"><input type="checkbox" name="blc_debug_mode" id="blc_debug_mode" <?php checked($debug_mode, true); ?>> Activer le journal de débogage</label>
-                                <p class="description">Écrit des informations dans <code>/wp-content/debug.log</code>. Nécessite que <code>WP_DEBUG_LOG</code> soit à <code>true</code> dans <code>wp-config.php</code>.</p>
+                                <label for="blc_debug_mode"><input type="checkbox" name="blc_debug_mode" id="blc_debug_mode" <?php checked($debug_mode, true); ?>> <?php esc_html_e('Activer le journal de débogage', 'liens-morts-detector-jlg'); ?></label>
+                                <p class="description">
+                                    <?php
+                                    echo wp_kses_post(
+                                        __('Écrit des informations dans <code>/wp-content/debug.log</code>. Nécessite que <code>WP_DEBUG_LOG</code> soit à <code>true</code> dans <code>wp-config.php</code>.', 'liens-morts-detector-jlg')
+                                    );
+                                    ?>
+                                </p>
                            </fieldset>
                         </td>
                     </tr>
                  </tbody>
             </table>
             <input type="hidden" name="blc_save_settings" value="1">
-            <?php submit_button('Enregistrer les modifications'); ?>
+            <?php submit_button(__('Enregistrer les modifications', 'liens-morts-detector-jlg')); ?>
         </form>
     </div>
     <?php

--- a/liens-morts-detector-jlg/languages/liens-morts-detector-jlg.pot
+++ b/liens-morts-detector-jlg/languages/liens-morts-detector-jlg.pot
@@ -1,0 +1,259 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: Liens Morts Detector - JLG 1.0\n"
+"POT-Creation-Date: 2025-09-16 11:48+0000\n"
+"PO-Revision-Date: 2025-09-16 11:48+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: ChatGPT\n"
+
+#: includes/blc-admin-pages.php:13 includes/blc-admin-pages.php:14
+msgid "Liens Morts"
+msgstr ""
+
+#: includes/blc-admin-pages.php:22 includes/blc-admin-pages.php:23
+msgid "Liens Cassés"
+msgstr ""
+
+#: includes/blc-admin-pages.php:30 includes/blc-admin-pages.php:31
+msgid "Images Cassées"
+msgstr ""
+
+#: includes/blc-admin-pages.php:38 includes/blc-admin-pages.php:39
+msgid "Réglages"
+msgstr ""
+
+#: includes/blc-admin-pages.php:58
+msgid "La vérification des liens a été programmée et s'exécute en arrière-plan."
+msgstr ""
+
+#: includes/blc-admin-pages.php:82 includes/blc-admin-pages.php:174
+msgid "Ko"
+msgstr ""
+
+#: includes/blc-admin-pages.php:83 includes/blc-admin-pages.php:175
+msgid "Mo"
+msgstr ""
+
+#: includes/blc-admin-pages.php:84 includes/blc-admin-pages.php:176
+msgid "Jamais"
+msgstr ""
+
+#: includes/blc-admin-pages.php:90
+msgid "Rapport des Liens Cassés"
+msgstr ""
+
+#: includes/blc-admin-pages.php:94
+msgid "Liens morts trouvés"
+msgstr ""
+
+#: includes/blc-admin-pages.php:98 includes/blc-admin-pages.php:190
+msgid "Poids des données"
+msgstr ""
+
+#: includes/blc-admin-pages.php:102
+msgid "Dernière analyse"
+msgstr ""
+
+#: includes/blc-admin-pages.php:115
+msgid "Lancer une %1$sanalyse complète%2$s de tous les articles (plus lent)"
+msgstr ""
+
+#: includes/blc-admin-pages.php:125
+msgid "Si non cochée, l'analyse ne portera que sur les articles modifiés depuis la dernière exécution."
+msgstr ""
+
+#: includes/blc-admin-pages.php:127
+msgid "Lancer la vérification des liens"
+msgstr ""
+
+#: includes/blc-admin-pages.php:130
+msgid "✅ Aucun lien mort trouvé. Bravo !"
+msgstr ""
+
+#: includes/blc-admin-pages.php:151
+msgid "La vérification des images a été programmée et s'exécute en arrière-plan."
+msgstr ""
+
+#: includes/blc-admin-pages.php:182
+msgid "Rapport des Images Cassées"
+msgstr ""
+
+#: includes/blc-admin-pages.php:186
+msgid "Images cassées trouvées"
+msgstr ""
+
+#: includes/blc-admin-pages.php:194
+msgid "Dernière analyse de liens"
+msgstr ""
+
+#: includes/blc-admin-pages.php:200
+msgid "L'analyse des images peut être longue et consommer des ressources. Elle s'exécute en arrière-plan sur l'ensemble du site."
+msgstr ""
+
+#: includes/blc-admin-pages.php:201
+msgid "Lancer l'analyse des images"
+msgstr ""
+
+#: includes/blc-admin-pages.php:204
+msgid "✅ Aucune image cassée trouvée. Bravo !"
+msgstr ""
+
+#: includes/blc-admin-pages.php:233
+msgid "Réglages enregistrés !"
+msgstr ""
+
+#: includes/blc-admin-pages.php:247
+msgid "Réglages des liens morts"
+msgstr ""
+
+#: includes/blc-admin-pages.php:250
+msgid "Planification"
+msgstr ""
+
+#: includes/blc-admin-pages.php:254
+msgid "Fréquence de vérification"
+msgstr ""
+
+#: includes/blc-admin-pages.php:257
+msgid "Quotidienne"
+msgstr ""
+
+#: includes/blc-admin-pages.php:258
+msgid "Hebdomadaire"
+msgstr ""
+
+#: includes/blc-admin-pages.php:259
+msgid "Mensuelle"
+msgstr ""
+
+#: includes/blc-admin-pages.php:264
+msgid "Fréquence de la vérification automatique des <strong>liens</strong>."
+msgstr ""
+
+#: includes/blc-admin-pages.php:274
+msgid "😴 Plage horaire de repos"
+msgstr ""
+
+#: includes/blc-admin-pages.php:276
+msgid "Ne pas lancer de scan entre"
+msgstr ""
+
+#: includes/blc-admin-pages.php:278
+msgid "et"
+msgstr ""
+
+#: includes/blc-admin-pages.php:283
+msgid "Le scan automatique des <strong>liens</strong> ne s'exécutera pas durant cette période. (Fuseau horaire de Paris)"
+msgstr ""
+
+#: includes/blc-admin-pages.php:294
+msgid "Performance"
+msgstr ""
+
+#: includes/blc-admin-pages.php:298
+msgid "⚙️ Délai entre chaque lien"
+msgstr ""
+
+#: includes/blc-admin-pages.php:300
+msgid "ms"
+msgstr ""
+
+#: includes/blc-admin-pages.php:301
+msgid "Pause après la vérification de chaque URL. (Défaut : 200)"
+msgstr ""
+
+#: includes/blc-admin-pages.php:305
+msgid "⚙️ Délai entre chaque lot"
+msgstr ""
+
+#: includes/blc-admin-pages.php:307
+msgid "secondes"
+msgstr ""
+
+#: includes/blc-admin-pages.php:308
+msgid "Pause entre chaque groupe de 20 articles analysés. (Défaut : 60)"
+msgstr ""
+
+#: includes/blc-admin-pages.php:313
+msgid "Méthode d'Analyse"
+msgstr ""
+
+#: includes/blc-admin-pages.php:317
+msgid "Stratégie de vérification"
+msgstr ""
+
+#: includes/blc-admin-pages.php:322
+msgid "Précise (recommandé)"
+msgstr ""
+
+#: includes/blc-admin-pages.php:323
+msgid "Simule un navigateur. Réduit les faux positifs, mais est un peu plus lent."
+msgstr ""
+
+#: includes/blc-admin-pages.php:327
+msgid "Rapide"
+msgstr ""
+
+#: includes/blc-admin-pages.php:328
+msgid "Vérification basique. Très léger, mais peut générer des faux positifs."
+msgstr ""
+
+#: includes/blc-admin-pages.php:334
+msgid "Liste d'exclusion"
+msgstr ""
+
+#: includes/blc-admin-pages.php:337
+msgid "Domaines à ignorer pendant l'analyse. Un domaine par ligne (ex: amazon.fr)."
+msgstr ""
+
+#: includes/blc-admin-pages.php:342
+msgid "Débogage"
+msgstr ""
+
+#: includes/blc-admin-pages.php:346
+msgid "Mode Débogage"
+msgstr ""
+
+#: includes/blc-admin-pages.php:349
+msgid "Activer le journal de débogage"
+msgstr ""
+
+#: includes/blc-admin-pages.php:353
+msgid "Écrit des informations dans <code>/wp-content/debug.log</code>. Nécessite que <code>WP_DEBUG_LOG</code> soit à <code>true</code> dans <code>wp-config.php</code>."
+msgstr ""
+
+#: includes/blc-admin-pages.php:363
+msgid "Enregistrer les modifications"
+msgstr ""
+
+#. translators: %s: original URL displayed in the edit prompt.
+#: liens-morts-detector-jlg.php:86
+msgid ""
+"Entrez la nouvelle URL pour :\n"
+"%s"
+msgstr ""
+
+#: liens-morts-detector-jlg.php:87
+msgid "https://"
+msgstr ""
+
+#: liens-morts-detector-jlg.php:88
+msgid "Êtes-vous sûr de vouloir supprimer ce lien ? Le texte sera conservé."
+msgstr ""
+
+#: liens-morts-detector-jlg.php:89
+msgid "Erreur : "
+msgstr ""
+
+#: includes/blc-cron.php:20
+msgid "Une fois par semaine"
+msgstr ""
+
+#: includes/blc-cron.php:26
+msgid "Une fois par mois"
+msgstr ""

--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -78,6 +78,18 @@ function blc_enqueue_admin_assets($hook) {
         filemtime(__DIR__ . '/assets/js/blc-admin-scripts.js'),
         true // Charger dans le pied de page pour de meilleures performances
     );
+
+    wp_localize_script(
+        'blc-admin-js',
+        'blcAdminMessages',
+        array(
+            /* translators: %s: original URL displayed in the edit prompt. */
+            'editPromptMessage'  => __("Entrez la nouvelle URL pour :\n%s", 'liens-morts-detector-jlg'),
+            'editPromptDefault'  => __('https://', 'liens-morts-detector-jlg'),
+            'unlinkConfirmation' => __('Êtes-vous sûr de vouloir supprimer ce lien ? Le texte sera conservé.', 'liens-morts-detector-jlg'),
+            'errorPrefix'        => __('Erreur : ', 'liens-morts-detector-jlg'),
+        )
+    );
 }
 
 // --- Fonctions de rappel AJAX pour les actions rapides ---


### PR DESCRIPTION
## Summary
- wrap admin menu labels, dashboard content, and settings copy in translation helpers
- surface localized strings to JavaScript via `wp_localize_script` and consume them in the admin script
- refresh the language template with the new translatable strings

## Testing
- php -l liens-morts-detector-jlg/includes/blc-admin-pages.php
- php -l liens-morts-detector-jlg/liens-morts-detector-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68c94cd023e8832eabdc691854dc102f