### PR TITLE
Refactor link updates and add utility tests

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-utils.php
+++ b/liens-morts-detector-jlg/includes/blc-utils.php
@@ -52,3 +52,72 @@ function blc_load_dom_from_post($post_content) {
         'xpath' => new DOMXPath($dom),
     ];
 }
+
+/**
+ * Met à jour le contenu d'un article en appliquant une modification sur les liens correspondant à une URL donnée.
+ *
+ * La fonction charge le contenu de l'article, recherche les balises <a> ciblées, applique la callback fournie
+ * puis enregistre le contenu mis à jour.
+ *
+ * @param int      $post_id    Identifiant de l'article à modifier.
+ * @param string   $target_url URL du lien à rechercher dans le contenu.
+ * @param callable $callback   Fonction appelée avec le DOMDocument et la liste des balises <a> correspondantes.
+ *                             Elle doit effectuer les modifications nécessaires sur le DOM.
+ *
+ * @return array{success: true, content: string}|array{error: string} Résultat de l'opération.
+ */
+function blc_update_link_in_post($post_id, $target_url, callable $callback) {
+    $post = get_post($post_id);
+    if (!$post) {
+        return ['error' => 'Article non trouvé.'];
+    }
+
+    $dom_data = blc_load_dom_from_post($post->post_content);
+    if (isset($dom_data['error'])) {
+        return ['error' => $dom_data['error']];
+    }
+
+    /** @var DOMDocument $dom */
+    $dom = $dom_data['dom'];
+    /** @var DOMXPath $xpath */
+    $xpath = $dom_data['xpath'];
+
+    $escaped_url = function_exists('esc_attr')
+        ? esc_attr($target_url)
+        : htmlspecialchars($target_url, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+
+    $anchors = $xpath->query(sprintf('//a[@href="%s"]', $escaped_url));
+
+    if ($anchors->length === 0) {
+        return ['error' => 'Le lien n\'a pas été trouvé dans le contenu de l\'article.'];
+    }
+
+    $callback_result = $callback($dom, $anchors);
+    if (is_array($callback_result) && isset($callback_result['error'])) {
+        return $callback_result;
+    }
+
+    $new_content = $dom->saveHTML();
+    $slashed_content = function_exists('wp_slash') ? wp_slash($new_content) : $new_content;
+
+    $update_result = wp_update_post([
+        'ID' => $post_id,
+        'post_content' => $slashed_content,
+    ], true);
+
+    $is_wp_error = function_exists('is_wp_error') && is_wp_error($update_result);
+
+    if (!$update_result || $is_wp_error) {
+        $error_message = 'La mise à jour de l\'article a échoué.';
+        if ($is_wp_error && method_exists($update_result, 'get_error_message')) {
+            $error_message .= ' ' . $update_result->get_error_message();
+        }
+
+        return ['error' => $error_message];
+    }
+
+    return [
+        'success' => true,
+        'content' => $new_content,
+    ];
+}

--- a/tests/AdminListTablesTest.php
+++ b/tests/AdminListTablesTest.php
@@ -27,6 +27,12 @@ class AdminListTablesTest extends TestCase
         }
 
         Functions\when('home_url')->justReturn('https://example.com');
+        Functions\when('sanitize_text_field')->alias(function ($value) {
+            return is_string($value) ? trim($value) : $value;
+        });
+        Functions\when('wp_unslash')->alias(function ($value) {
+            return $value;
+        });
 
         require_once __DIR__ . '/../liens-morts-detector-jlg/includes/class-blc-links-list-table.php';
         require_once __DIR__ . '/../liens-morts-detector-jlg/includes/class-blc-images-list-table.php';

--- a/tests/BlcAjaxCallbacksTest.php
+++ b/tests/BlcAjaxCallbacksTest.php
@@ -29,6 +29,15 @@ class BlcAjaxCallbacksTest extends TestCase
         Functions\when('wp_unslash')->alias(function ($value) {
             return $value;
         });
+        Functions\when('wp_http_validate_url')->alias(function ($url) {
+            return $url;
+        });
+        Functions\when('esc_url_raw')->alias(function ($url) {
+            return $url;
+        });
+        Functions\when('is_wp_error')->alias(function ($thing): bool {
+            return is_object($thing) && method_exists($thing, 'get_error_message');
+        });
 
         require_once __DIR__ . '/../liens-morts-detector-jlg/liens-morts-detector-jlg.php';
     }

--- a/tests/BlcUtilsTest.php
+++ b/tests/BlcUtilsTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class BlcUtilsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        require_once __DIR__ . '/../vendor/autoload.php';
+        Monkey\setUp();
+
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', __DIR__ . '/../');
+        }
+
+        require_once __DIR__ . '/../liens-morts-detector-jlg/includes/blc-utils.php';
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_returns_error_when_post_is_not_found(): void
+    {
+        Functions\expect('get_post')->once()->with(123)->andReturn(null);
+
+        $callbackCalled = false;
+        $result = blc_update_link_in_post(123, 'http://example.com', function () use (&$callbackCalled) {
+            $callbackCalled = true;
+        });
+
+        $this->assertFalse($callbackCalled);
+        $this->assertArrayHasKey('error', $result);
+        $this->assertSame('Article non trouvé.', $result['error']);
+    }
+
+    public function test_returns_error_when_dom_loading_fails(): void
+    {
+        $content = '<a href="http://example.com">Link</a>';
+        Functions\expect('get_post')->once()->with(5)->andReturn((object) ['post_content' => $content]);
+        Functions\expect('blc_load_dom_from_post')->once()->with($content)->andReturn(['error' => 'DOM error']);
+
+        $result = blc_update_link_in_post(5, 'http://example.com', function () {
+        });
+
+        $this->assertArrayHasKey('error', $result);
+        $this->assertSame('DOM error', $result['error']);
+    }
+
+    public function test_returns_error_when_link_is_missing(): void
+    {
+        Functions\expect('get_post')->once()->with(7)->andReturn((object) ['post_content' => '<p>Content</p>']);
+
+        $callbackCalled = false;
+        $result = blc_update_link_in_post(7, 'http://old.com', function () use (&$callbackCalled) {
+            $callbackCalled = true;
+        });
+
+        $this->assertFalse($callbackCalled);
+        $this->assertArrayHasKey('error', $result);
+        $this->assertSame('Le lien n\'a pas été trouvé dans le contenu de l\'article.', $result['error']);
+    }
+
+    public function test_returns_error_when_update_fails(): void
+    {
+        Functions\expect('get_post')->once()->with(8)->andReturn((object) ['post_content' => '<a href="http://old.com">Link</a>']);
+        Functions\expect('wp_update_post')->once()->andReturn(false);
+
+        $callbackCalled = false;
+        $result = blc_update_link_in_post(8, 'http://old.com', function (\DOMDocument $dom, \DOMNodeList $anchors) use (&$callbackCalled) {
+            $callbackCalled = true;
+            foreach ($anchors as $anchor) {
+                $anchor->setAttribute('href', 'http://new.com');
+            }
+        });
+
+        $this->assertTrue($callbackCalled);
+        $this->assertArrayHasKey('error', $result);
+        $this->assertSame('La mise à jour de l\'article a échoué.', $result['error']);
+    }
+
+    public function test_updates_content_and_returns_success(): void
+    {
+        Functions\expect('get_post')->once()->with(9)->andReturn((object) ['post_content' => '<p><a href="http://old.com">Link</a></p>']);
+
+        $updatedData = [];
+        Functions\expect('wp_update_post')->once()->andReturnUsing(function ($data) use (&$updatedData) {
+            $updatedData = $data;
+            return true;
+        });
+
+        $result = blc_update_link_in_post(9, 'http://old.com', function (\DOMDocument $dom, \DOMNodeList $anchors) {
+            foreach ($anchors as $anchor) {
+                $anchor->setAttribute('href', 'http://new.com');
+            }
+        });
+
+        $this->assertArrayHasKey('success', $result);
+        $this->assertTrue($result['success']);
+        $this->assertSame('<p><a href="http://new.com">Link</a></p>', trim($result['content']));
+        $this->assertSame(9, $updatedData['ID'] ?? null);
+        $this->assertSame('<p><a href="http://new.com">Link</a></p>', isset($updatedData['post_content']) ? trim(stripslashes($updatedData['post_content'])) : null);
+    }
+}


### PR DESCRIPTION
## Summary
- add `blc_update_link_in_post` to centralize DOM loading, anchor lookup, and post updates
- refactor the AJAX edit and unlink callbacks to rely on the new helper via dedicated closures
- add a dedicated test suite for the helper and extend existing tests with the required WordPress stubs

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68c953eb9418832e8df40724e5ab8f15