### PR TITLE
Use safe HTTP requests in link scanner

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -175,7 +175,7 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
 
             if ($is_excluded) { continue; }
 
-            $response = ($scan_method === 'precise') ? wp_remote_get($url, ['timeout' => 10, 'user-agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0', 'method' => 'GET']) : wp_remote_head($url, ['timeout' => 5]);
+            $response = ($scan_method === 'precise') ? wp_safe_remote_get($url, ['timeout' => 10, 'user-agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0', 'method' => 'GET']) : wp_safe_remote_head($url, ['timeout' => 5]);
 
             if (is_wp_error($response) || wp_remote_retrieve_response_code($response) >= 400) {
                 $wpdb->insert(


### PR DESCRIPTION
## Summary
- replace the link scanner HTTP helpers with the wp_safe_remote_* variants to harden requests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c967373250832e990710fcf2daad91