### PR TITLE
Add host safety validation before remote link checks

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -193,6 +193,11 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
 
             if ($is_excluded) { continue; }
 
+            if (!blc_is_safe_remote_host($host)) {
+                if ($debug_mode) { error_log("  -> Lien ignoré (IP non autorisée) : " . $url); }
+                continue;
+            }
+
             $response = ($scan_method === 'precise') ? wp_safe_remote_get($url, ['timeout' => 10, 'user-agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0', 'method' => 'GET']) : wp_safe_remote_head($url, ['timeout' => 5]);
 
             if (is_wp_error($response) || wp_remote_retrieve_response_code($response) >= 400) {

--- a/liens-morts-detector-jlg/includes/blc-utils.php
+++ b/liens-morts-detector-jlg/includes/blc-utils.php
@@ -129,3 +129,191 @@ function blc_prepare_time_input_value($value, $default = '00') {
 
     return $hour . ':00';
 }
+
+/**
+ * Check whether a resolved IP address is considered public and safe for remote requests.
+ *
+ * @param string $ip Raw IP address.
+ *
+ * @return bool True when the IP is public, false otherwise.
+ */
+function blc_is_public_ip_address($ip) {
+    $ip = trim((string) $ip);
+    if ($ip === '') {
+        return false;
+    }
+
+    if (filter_var($ip, FILTER_VALIDATE_IP) === false) {
+        return false;
+    }
+
+    $flags = FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE;
+    if (filter_var($ip, FILTER_VALIDATE_IP, $flags) === false) {
+        return false;
+    }
+
+    $packed = @inet_pton($ip);
+    if ($packed === false) {
+        return false;
+    }
+
+    if (strlen($packed) === 4) {
+        return blc_is_public_ipv4($ip);
+    }
+
+    return blc_is_public_ipv6($ip, $packed);
+}
+
+/**
+ * Determine if an IPv4 address falls outside additional blocked ranges.
+ *
+ * @param string $ip IPv4 address.
+ *
+ * @return bool
+ */
+function blc_is_public_ipv4($ip) {
+    if (filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) === false) {
+        return false;
+    }
+
+    $flags = FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE;
+    if (filter_var($ip, FILTER_VALIDATE_IP, $flags) === false) {
+        return false;
+    }
+
+    $parts = array_map('intval', explode('.', $ip));
+    if (count($parts) !== 4) {
+        return false;
+    }
+
+    if ($parts[0] === 169 && $parts[1] === 254) {
+        return false; // Link-local range 169.254.0.0/16.
+    }
+
+    if ($parts[0] === 100 && $parts[1] >= 64 && $parts[1] <= 127) {
+        return false; // CGNAT / carrier-grade NAT range 100.64.0.0/10.
+    }
+
+    return true;
+}
+
+/**
+ * Determine if an IPv6 address falls outside additional blocked ranges.
+ *
+ * @param string   $ip     IPv6 address.
+ * @param string|null $packed Optional packed representation returned by inet_pton().
+ *
+ * @return bool
+ */
+function blc_is_public_ipv6($ip, $packed = null) {
+    if ($packed === null) {
+        $packed = @inet_pton($ip);
+    }
+
+    if ($packed === false || strlen($packed) !== 16) {
+        return false;
+    }
+
+    $canonical = strtolower((string) @inet_ntop($packed));
+    if ($canonical === '::1') {
+        return false; // IPv6 loopback.
+    }
+
+    $words = unpack('n*', $packed);
+    if (!is_array($words) || count($words) < 8) {
+        return false;
+    }
+
+    if (($words[1] & 0xFFC0) === 0xFE80) {
+        return false; // IPv6 link-local fe80::/10.
+    }
+
+    $is_ipv4_mapped = (
+        $words[1] === 0 &&
+        $words[2] === 0 &&
+        $words[3] === 0 &&
+        $words[4] === 0 &&
+        $words[5] === 0 &&
+        $words[6] === 0xFFFF
+    );
+
+    if ($is_ipv4_mapped) {
+        $mapped_ipv4 = @inet_ntop(substr($packed, 12, 4));
+        if ($mapped_ipv4 === false) {
+            return false;
+        }
+
+        return blc_is_public_ipv4($mapped_ipv4);
+    }
+
+    return true;
+}
+
+/**
+ * Validate that the provided host resolves to public IP addresses.
+ *
+ * @param string $host Hostname or IP address extracted from the URL.
+ *
+ * @return bool True when every resolved IP is public.
+ */
+function blc_is_safe_remote_host($host) {
+    $host = trim((string) $host);
+    if ($host === '') {
+        return false;
+    }
+
+    $ip_addresses = [];
+
+    if (filter_var($host, FILTER_VALIDATE_IP)) {
+        $ip_addresses[] = $host;
+    } else {
+        if (function_exists('dns_get_record')) {
+            $record_types = 0;
+            if (defined('DNS_A')) {
+                $record_types |= DNS_A;
+            }
+            if (defined('DNS_AAAA')) {
+                $record_types |= DNS_AAAA;
+            }
+
+            if ($record_types !== 0) {
+                $records = @dns_get_record($host, $record_types);
+            } else {
+                $records = false;
+            }
+
+            if (is_array($records)) {
+                foreach ($records as $record) {
+                    if (isset($record['ip'])) {
+                        $ip_addresses[] = $record['ip'];
+                    } elseif (isset($record['ipv6'])) {
+                        $ip_addresses[] = $record['ipv6'];
+                    }
+                }
+            }
+        }
+
+        if (empty($ip_addresses)) {
+            $ipv4_records = @gethostbynamel($host);
+            if (is_array($ipv4_records)) {
+                foreach ($ipv4_records as $ip) {
+                    $ip_addresses[] = $ip;
+                }
+            }
+        }
+    }
+
+    if (empty($ip_addresses)) {
+        return true; // Unable to resolve, let WordPress handle the failure.
+    }
+
+    $ip_addresses = array_unique($ip_addresses);
+
+    foreach ($ip_addresses as $ip) {
+        if (!blc_is_public_ip_address($ip)) {
+            return false;
+        }
+    }
+
+    return true;
+}


### PR DESCRIPTION
## Summary
- add utilities to verify resolved IP addresses and reject private, link-local or CGNAT ranges
- skip remote link checks when the host resolves to a restricted address and log the decision in debug mode

## Testing
- php -l liens-morts-detector-jlg/includes/blc-utils.php
- php -l liens-morts-detector-jlg/includes/blc-scanner.php

------
https://chatgpt.com/codex/tasks/task_e_68c9d6813080832ebc6b9ea6790dbd20