### PR TITLE
Block non-public endpoints before remote scans

### DIFF
--- a/patchwork.json
+++ b/patchwork.json
@@ -1,6 +1,8 @@
 {
     "redefinable-internals": [
         "sys_getloadavg",
-        "time"
+        "time",
+        "dns_get_record",
+        "gethostbynamel"
     ]
 }


### PR DESCRIPTION
## Summary
- add a helper that resolves link hosts and rejects private or reserved IPs, with a filter for whitelisting
- call the helper before performing HTTP checks so private endpoints are skipped with optional debug logging
- extend the test suite and Patchwork configuration to cover DNS lookups and whitelisted hosts

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68c9d67f67fc832ea3ef5bf0edf3b055