### PR TITLE
Clarifier la documentation sur les actions rapides

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,10 @@
 Liens Morts Detector est une extension WordPress qui détecte les liens et images morts, les signale dans l’administration et propose des outils de réparation rapide. L’analyse peut s’exécuter automatiquement via WP‑Cron ou manuellement depuis le tableau de bord.
 
 ## Fonctionnalités
-- Vérification automatique des liens `<a>` et des images `<img>` grâce à WP‑Cron  
-- Planification quotidienne, hebdomadaire ou mensuelle  
-- Tableau de bord listant les liens et images cassés avec statistiques  
-- Actions rapides pour modifier une URL ou retirer un lien directement depuis la liste  
+- Vérification automatique des liens `<a>` et des images `<img>` grâce à WP‑Cron
+- Planification quotidienne, hebdomadaire ou mensuelle
+- Tableau de bord listant les liens et images cassés avec statistiques
+- Actions rapides (modifier/dissocier) disponibles pour les liens ; les images proposent un accès direct à l’édition de l’article concerné
 - Options avancées : exclusion de domaines, plages horaires de repos, mode debug
 
 ## Installation
@@ -16,7 +16,7 @@ Liens Morts Detector est une extension WordPress qui détecte les liens et image
 
 ## Utilisation
 - La vérification s’exécute automatiquement selon la fréquence choisie ou manuellement via un bouton sur les pages de rapport.
-- Les liens ou images détectés comme cassés apparaissent dans une table permettant la modification rapide de l’URL ou la suppression du lien.
+- Les liens et images détectés comme cassés apparaissent dans une table : les liens bénéficient d’actions rapides pour modifier leur URL ou les dissocier, tandis que les images offrent uniquement un raccourci vers l’édition de l’article d’origine.
 - Des réglages avancés permettent d’exclure certains domaines, de limiter l’analyse à des plages horaires et d’activer un mode debug pour le suivi.
 
 ## Hooks disponibles


### PR DESCRIPTION
## Summary
- préciser que les actions rapides de modification/dissociation ne s'appliquent qu'aux liens
- indiquer que les images ne disposent que d'un lien vers l'édition de l'article d'origine

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68c9dd964a4c832eb4dbc0adfdb1dc2d