### PR TITLE
Normalize URL handling for scheme-relative links

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -7,6 +7,45 @@ if (!function_exists('blc_normalize_hour_option')) {
 }
 
 /**
+ * Normalize a link URL while preserving the original value for storage/display.
+ *
+ * @param string      $url        Original URL extracted from the content.
+ * @param string      $site_url   Site URL with trailing slash.
+ * @param string|null $site_scheme Current site scheme (http/https).
+ *
+ * @return string Normalized URL suitable for validation.
+ */
+function blc_normalize_link_url($url, $site_url, $site_scheme = null) {
+    $url = (string) $url;
+    if ($url === '') {
+        return '';
+    }
+
+    if (strpos($url, '//') === 0) {
+        $scheme = ($site_scheme !== null && $site_scheme !== '') ? $site_scheme : 'http';
+        return set_url_scheme($url, $scheme);
+    }
+
+    $parsed_url = parse_url($url);
+    if ($parsed_url === false) {
+        return '';
+    }
+
+    if (!empty($parsed_url['scheme'])) {
+        return $url;
+    }
+
+    $site_url = rtrim((string) $site_url, '/') . '/';
+
+    if (isset($parsed_url['path']) && strpos($parsed_url['path'], '/') === 0) {
+        $base = rtrim($site_url, '/');
+        return $base . $url;
+    }
+
+    return $site_url . ltrim($url, '/');
+}
+
+/**
  * Helper to build a DOMDocument instance from raw post content.
  *
  * @param string $content Raw HTML content from the post.
@@ -120,7 +159,25 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
     $upload_dir_info = wp_upload_dir();
     $upload_baseurl  = isset($upload_dir_info['baseurl']) ? trailingslashit($upload_dir_info['baseurl']) : '';
     $upload_basedir  = isset($upload_dir_info['basedir']) ? trailingslashit($upload_dir_info['basedir']) : '';
-    $site_url        = trailingslashit(home_url());
+    $raw_home_url    = home_url();
+    $site_url        = trailingslashit($raw_home_url);
+    $site_scheme     = parse_url($raw_home_url, PHP_URL_SCHEME);
+    if (!is_string($site_scheme) || $site_scheme === '') {
+        $site_scheme = 'http';
+    }
+    $normalized_upload_baseurl = '';
+    $upload_base_host = '';
+    $upload_base_path = '';
+    if ($upload_baseurl !== '') {
+        $normalized_upload_baseurl = trailingslashit(set_url_scheme($upload_baseurl, $site_scheme));
+        $upload_base_parts = parse_url($normalized_upload_baseurl);
+        if (is_array($upload_base_parts)) {
+            $upload_base_host = isset($upload_base_parts['host']) ? strtolower($upload_base_parts['host']) : '';
+            if (isset($upload_base_parts['path'])) {
+                $upload_base_path = rtrim($upload_base_parts['path'], '/');
+            }
+        }
+    }
 
     $blog_charset = get_bloginfo('charset');
     if (empty($blog_charset)) { $blog_charset = 'UTF-8'; }
@@ -134,49 +191,52 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
         }
 
         foreach ($dom->getElementsByTagName('a') as $link_node) {
-            $url = trim(wp_kses_decode_entities($link_node->getAttribute('href')));
-            if ($url === '') { continue; }
+            $original_url = trim(wp_kses_decode_entities($link_node->getAttribute('href')));
+            if ($original_url === '') { continue; }
 
             $anchor_text = wp_strip_all_tags($link_node->textContent);
             $anchor_text = trim(preg_replace('/\s+/u', ' ', $anchor_text));
             if ($anchor_text === '') { $anchor_text = '[Lien sans texte]'; }
 
-            $parsed_url = parse_url($url);
+            $normalized_url = blc_normalize_link_url($original_url, $site_url, $site_scheme);
+            if ($normalized_url === '') {
+                continue;
+            }
+
+            $parsed_url = parse_url($normalized_url);
             if ($parsed_url === false) {
                 continue;
             }
 
-            if (empty($parsed_url['scheme'])) {
-                $url = $site_url . ltrim($url, '/');
-                $parsed_url = parse_url($url);
-                if ($parsed_url === false) {
-                    continue;
+            if (empty($parsed_url['scheme']) || !in_array($parsed_url['scheme'], ['http', 'https'], true)) { continue; }
+
+            if ($upload_basedir && $upload_base_host && isset($parsed_url['host']) && isset($parsed_url['path'])) {
+                if (strcasecmp($upload_base_host, $parsed_url['host']) === 0 && $upload_base_path !== '' && strpos($parsed_url['path'], $upload_base_path) === 0) {
+                    $relative_path = ltrim(substr($parsed_url['path'], strlen($upload_base_path)), '/');
+                    if ($relative_path === '') {
+                        continue;
+                    }
+                    $file_path = wp_normalize_path($upload_basedir . $relative_path);
+
+                    if (!file_exists($file_path)) {
+                        if ($debug_mode) { error_log("  -> Ressource locale introuvable : " . $normalized_url); }
+                        $wpdb->insert(
+                            $table_name,
+                            [
+                                'url'        => $original_url,
+                                'anchor'     => $anchor_text,
+                                'post_id'    => $post->ID,
+                                'post_title' => $post->post_title,
+                                'type'       => 'link',
+                            ],
+                            ['%s', '%s', '%d', '%s', '%s']
+                        );
+                        continue;
+                    }
                 }
             }
-            elseif (!in_array($parsed_url['scheme'], ['http', 'https'])) { continue; }
 
-            if ($upload_baseurl && $upload_basedir && strpos($url, $upload_baseurl) === 0) {
-                $relative_path = ltrim(substr($url, strlen($upload_baseurl)), '/');
-                $file_path = wp_normalize_path($upload_basedir . $relative_path);
-
-                if (!file_exists($file_path)) {
-                    if ($debug_mode) { error_log("  -> Ressource locale introuvable : " . $url); }
-                    $wpdb->insert(
-                        $table_name,
-                        [
-                            'url'        => $url,
-                            'anchor'     => $anchor_text,
-                            'post_id'    => $post->ID,
-                            'post_title' => $post->post_title,
-                            'type'       => 'link',
-                        ],
-                        ['%s', '%s', '%d', '%s', '%s']
-                    );
-                    continue;
-                }
-            }
-
-            $host = parse_url($url, PHP_URL_HOST);
+            $host = parse_url($normalized_url, PHP_URL_HOST);
             if (!is_string($host) || $host === '') {
                 continue;
             }
@@ -194,17 +254,17 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
             if ($is_excluded) { continue; }
 
             if (!blc_is_safe_remote_host($host)) {
-                if ($debug_mode) { error_log("  -> Lien ignoré (IP non autorisée) : " . $url); }
+                if ($debug_mode) { error_log("  -> Lien ignoré (IP non autorisée) : " . $normalized_url); }
                 continue;
             }
 
-            $response = ($scan_method === 'precise') ? wp_safe_remote_get($url, ['timeout' => 10, 'user-agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0', 'method' => 'GET']) : wp_safe_remote_head($url, ['timeout' => 5]);
+            $response = ($scan_method === 'precise') ? wp_safe_remote_get($normalized_url, ['timeout' => 10, 'user-agent' => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0', 'method' => 'GET']) : wp_safe_remote_head($normalized_url, ['timeout' => 5]);
 
             if (is_wp_error($response) || wp_remote_retrieve_response_code($response) >= 400) {
                 $wpdb->insert(
                     $table_name,
                     [
-                        'url'        => $url,
+                        'url'        => $original_url,
                         'anchor'     => $anchor_text,
                         'post_id'    => $post->ID,
                         'post_title' => $post->post_title,

--- a/tests/BlcAjaxCallbacksTest.php
+++ b/tests/BlcAjaxCallbacksTest.php
@@ -26,6 +26,19 @@ class BlcAjaxCallbacksTest extends TestCase
             return dirname($file) . '/';
         });
         Functions\when('plugin_dir_url')->justReturn('http://example.com/');
+        Functions\when('home_url')->justReturn('https://example.com');
+        Functions\when('trailingslashit')->alias(function ($value) {
+            return rtrim((string) $value, "\\/\t\n\r\f ") . '/';
+        });
+        Functions\when('set_url_scheme')->alias(function ($url, $scheme = null) {
+            $scheme = $scheme ?: 'http';
+
+            if (strpos($url, '//') === 0) {
+                return $scheme . ':' . $url;
+            }
+
+            return preg_replace('#^[a-z0-9+.-]+://#i', $scheme . '://', $url);
+        });
         Functions\when('wp_unslash')->alias(function ($value) {
             return $value;
         });

--- a/tests/BlcScannerTest.php
+++ b/tests/BlcScannerTest.php
@@ -56,6 +56,12 @@ class BlcScannerTest extends TestCase
 
     private string $currentHour = '00';
 
+    /** @var array<int, array<string, mixed>> */
+    private array $updatedPosts = [];
+
+    /** @var array{success: bool, data: mixed}|null */
+    private ?array $ajaxResponse = null;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -83,12 +89,30 @@ class BlcScannerTest extends TestCase
         $this->updatedOptions = [];
         $this->serverLoad = [0.5, 0.4, 0.3];
         $this->currentHour = '00';
+        $this->updatedPosts = [];
+        $this->ajaxResponse = null;
         $GLOBALS['wp_query_queue'] = [];
         $GLOBALS['wp_query_last_args'] = [];
 
         Functions\when('get_option')->alias(fn(string $name, $default = false) => $this->options[$name] ?? $default);
         Functions\when('apply_filters')->alias(fn(string $hook, $value, ...$args) => $value);
-        Functions\when('home_url')->justReturn('http://example.com');
+        Functions\when('home_url')->alias(function ($path = '', $scheme = null) {
+            $base = 'https://example.com';
+            if ($path !== '') {
+                return rtrim($base, '/') . '/' . ltrim($path, '/');
+            }
+
+            return $base;
+        });
+        Functions\when('set_url_scheme')->alias(function ($url, $scheme = null) {
+            $scheme = $scheme ?: 'http';
+
+            if (strpos($url, '//') === 0) {
+                return $scheme . ':' . $url;
+            }
+
+            return preg_replace('#^[a-z0-9+.-]+://#i', $scheme . '://', $url);
+        });
         Functions\when('current_time')->alias(function (string $type) {
             if ($type === 'timestamp') {
                 return 1000;
@@ -105,7 +129,7 @@ class BlcScannerTest extends TestCase
         });
         Functions\when('wp_upload_dir')->alias(function () {
             return [
-                'baseurl' => 'http://example.com/wp-content/uploads',
+                'baseurl' => 'https://example.com/wp-content/uploads',
                 'basedir' => sys_get_temp_dir() . '/uploads-test',
             ];
         });
@@ -150,8 +174,32 @@ class BlcScannerTest extends TestCase
 
             return '';
         });
+        Functions\when('check_ajax_referer')->justReturn(true);
+        Functions\when('current_user_can')->justReturn(true);
+        Functions\when('get_post')->alias(fn(int $post_id) => null);
+        Functions\when('wp_http_validate_url')->alias(function ($url) {
+            if (!is_string($url)) {
+                return false;
+            }
+
+            $url = trim($url);
+            if ($url === '') {
+                return false;
+            }
+
+            if (preg_match('#^https?://#i', $url) === 1) {
+                return $url;
+            }
+
+            return false;
+        });
+        Functions\when('esc_url_raw')->alias(fn($url) => is_string($url) ? $url : '');
         Functions\when('update_option')->alias(function (string $option, $value) {
             $this->updatedOptions[$option] = $value;
+            return true;
+        });
+        Functions\when('wp_update_post')->alias(function (array $data, $wp_error = false) {
+            $this->updatedPosts[] = ['data' => $data, 'wp_error' => $wp_error];
             return true;
         });
         Functions\when('wp_schedule_single_event')->alias(function (int $timestamp, string $hook, array $args = [], bool $unique = true) {
@@ -167,8 +215,17 @@ class BlcScannerTest extends TestCase
         Functions\when('time')->justReturn(1000);
         Functions\when('wp_unslash')->alias(fn($value) => $value);
         Functions\when('wp_slash')->alias(fn($value) => $value);
+        Functions\when('wp_send_json_success')->alias(function ($data = null) {
+            $this->ajaxResponse = ['success' => true, 'data' => $data];
+            throw new \RuntimeException('wp_send_json_success');
+        });
+        Functions\when('wp_send_json_error')->alias(function ($data = null) {
+            $this->ajaxResponse = ['success' => false, 'data' => $data];
+            throw new \RuntimeException('wp_send_json_error');
+        });
 
         require_once __DIR__ . '/../liens-morts-detector-jlg/includes/blc-scanner.php';
+        require_once __DIR__ . '/../liens-morts-detector-jlg/liens-morts-detector-jlg.php';
     }
 
     protected function tearDown(): void
@@ -176,6 +233,8 @@ class BlcScannerTest extends TestCase
         Monkey\tearDown();
         parent::tearDown();
         unset($GLOBALS['wp_query_queue'], $GLOBALS['wp_query_last_args']);
+        unset($_POST);
+        $this->ajaxResponse = null;
         global $wpdb;
         $wpdb = null;
     }
@@ -202,6 +261,8 @@ class BlcScannerTest extends TestCase
             public array $queries = [];
             /** @var array<int, array<string, mixed>> */
             public array $inserted = [];
+            /** @var array<int, array<string, mixed>> */
+            public array $deleted = [];
 
             public function query(string $sql)
             {
@@ -213,6 +274,12 @@ class BlcScannerTest extends TestCase
             {
                 $this->inserted[] = ['table' => $table, 'data' => $data, 'formats' => $formats];
                 return true;
+            }
+
+            public function delete(string $table, array $where, array $formats)
+            {
+                $this->deleted[] = ['table' => $table, 'where' => $where, 'formats' => $formats];
+                return 1;
             }
 
             public function prepare(string $query, $args = null): string
@@ -447,6 +514,79 @@ class BlcScannerTest extends TestCase
         $this->assertCount(0, $wpdb->inserted, 'Malformed URLs should be ignored.');
     }
 
+    public function test_blc_perform_check_handles_scheme_relative_urls(): void
+    {
+        global $wpdb;
+        $wpdb = $this->createWpdbStub();
+
+        $post = (object) [
+            'ID' => 314,
+            'post_title' => 'CDN Link Post',
+            'post_content' => '<a href="//cdn.example.com/foo">CDN Link</a>',
+        ];
+
+        $GLOBALS['wp_query_queue'][] = [
+            'posts' => [$post],
+            'max_num_pages' => 1,
+        ];
+
+        $this->setHttpResponse('GET', 'https://cdn.example.com/foo', ['response' => ['code' => 404]]);
+
+        blc_perform_check(0, false);
+
+        $this->assertCount(1, $this->httpRequests, 'Scheme-relative URLs should be requested once.');
+        $this->assertSame('https://cdn.example.com/foo', $this->httpRequests[0]['url']);
+
+        $this->assertCount(1, $wpdb->inserted, 'Broken scheme-relative URL should be recorded.');
+        $insert = $wpdb->inserted[0];
+        $this->assertSame('//cdn.example.com/foo', $insert['data']['url'], 'Original URL should be stored for UI consistency.');
+        $this->assertSame('link', $insert['data']['type']);
+        $this->assertSame('CDN Link', $insert['data']['anchor']);
+    }
+
+    public function test_blc_ajax_edit_link_callback_updates_scheme_relative_url(): void
+    {
+        global $wpdb;
+        $wpdb = $this->createWpdbStub();
+
+        $post_id = 512;
+        $original_content = '<p><a href="//cdn.example.com/foo">CDN Link</a></p>';
+
+        Functions\when('get_post')->alias(function (int $requested_post_id) use ($post_id, $original_content) {
+            if ($requested_post_id === $post_id) {
+                return (object) ['ID' => $post_id, 'post_content' => $original_content];
+            }
+
+            return null;
+        });
+
+        $_POST = [
+            'post_id'    => (string) $post_id,
+            'old_url'    => '//cdn.example.com/foo',
+            'new_url'    => 'https://cdn.example.com/bar',
+            '_ajax_nonce' => 'nonce',
+        ];
+
+        try {
+            blc_ajax_edit_link_callback();
+            $this->fail('Expected wp_send_json_success to terminate execution.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame('wp_send_json_success', $exception->getMessage());
+        }
+
+        $this->assertNotNull($this->ajaxResponse, 'AJAX response should be captured.');
+        $this->assertTrue($this->ajaxResponse['success'], 'AJAX call should succeed.');
+
+        $this->assertCount(1, $this->updatedPosts, 'The post content should be updated once.');
+        $update = $this->updatedPosts[0]['data'];
+        $this->assertSame($post_id, $update['ID']);
+        $this->assertStringContainsString('https://cdn.example.com/bar', $update['post_content']);
+        $this->assertStringNotContainsString('//cdn.example.com/foo', $update['post_content']);
+
+        $this->assertCount(1, $wpdb->deleted, 'Original URL should be removed from the broken links table.');
+        $this->assertSame('//cdn.example.com/foo', $wpdb->deleted[0]['where']['url']);
+    }
+
     public function test_blc_perform_check_batches_and_reschedules_next_batch(): void
     {
         global $wpdb;
@@ -530,7 +670,7 @@ class BlcScannerTest extends TestCase
         $post = (object) [
             'ID' => 88,
             'post_title' => 'Images Post',
-            'post_content' => '<img src="http://example.com/wp-content/uploads/2024/05/missing.jpg" />' .
+            'post_content' => '<img src="https://example.com/wp-content/uploads/2024/05/missing.jpg" />' .
                 '<img src="http://cdn.example.com/image.jpg" />',
         ];
 
@@ -563,7 +703,7 @@ class BlcScannerTest extends TestCase
         $post = (object) [
             'ID' => 90,
             'post_title' => 'Traversal Post',
-            'post_content' => '<img src="http://example.com/wp-content/uploads/2024/../secret.jpg" />',
+            'post_content' => '<img src="https://example.com/wp-content/uploads/2024/../secret.jpg" />',
         ];
 
         $GLOBALS['wp_query_queue'][] = [


### PR DESCRIPTION
## Summary
- normalize scanned link targets to resolve scheme-relative and relative URLs while preserving the original string for storage
- adjust the AJAX edit callback to validate and work with scheme-relative links without losing the original href
- extend unit coverage for CDN-style URLs and AJAX updates, updating fixtures to match the HTTPS site configuration

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68ca8415cd24832ea6ee8414e5f989e9