### PR TITLE
Normalize and truncate stored broken link data

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -265,6 +265,8 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
     foreach ($posts as $post) {
         if ($debug_mode) { error_log("Analyse LIENS pour : '" . $post->post_title . "'"); }
 
+        $post_title_for_storage = blc_prepare_text_field_for_storage($post->post_title);
+
         $dom = blc_create_dom_from_content($post->post_content, $blog_charset);
         if (!$dom instanceof DOMDocument) {
             continue;
@@ -277,6 +279,9 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
             $anchor_text = wp_strip_all_tags($link_node->textContent);
             $anchor_text = trim(preg_replace('/\s+/u', ' ', $anchor_text));
             if ($anchor_text === '') { $anchor_text = '[Lien sans texte]'; }
+
+            $url_for_storage    = blc_prepare_url_for_storage($original_url);
+            $anchor_for_storage = blc_prepare_text_field_for_storage($anchor_text);
 
             $normalized_url = blc_normalize_link_url($original_url, $site_url, $site_scheme);
             if ($normalized_url === '') {
@@ -303,10 +308,10 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
                         $wpdb->insert(
                             $table_name,
                             [
-                                'url'        => $original_url,
-                                'anchor'     => $anchor_text,
+                                'url'        => $url_for_storage,
+                                'anchor'     => $anchor_for_storage,
                                 'post_id'    => $post->ID,
-                                'post_title' => $post->post_title,
+                                'post_title' => $post_title_for_storage,
                                 'type'       => 'link',
                             ],
                             ['%s', '%s', '%d', '%s', '%s']
@@ -344,10 +349,10 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
                 $wpdb->insert(
                     $table_name,
                     [
-                        'url'        => $original_url,
-                        'anchor'     => $anchor_text,
+                        'url'        => $url_for_storage,
+                        'anchor'     => $anchor_for_storage,
                         'post_id'    => $post->ID,
-                        'post_title' => $post->post_title,
+                        'post_title' => $post_title_for_storage,
                         'type'       => 'link',
                     ],
                     ['%s', '%s', '%d', '%s', '%s']
@@ -400,6 +405,8 @@ function blc_perform_image_check($batch = 0, $is_full_scan = true) { // Une anal
 
     foreach ($posts as $post) {
         if ($debug_mode) { error_log("Analyse IMAGES pour : '" . $post->post_title . "'"); }
+
+        $post_title_for_storage = blc_prepare_text_field_for_storage($post->post_title);
 
         $dom = blc_create_dom_from_content($post->post_content, $blog_charset);
         if (!$dom instanceof DOMDocument) {
@@ -461,13 +468,15 @@ function blc_perform_image_check($batch = 0, $is_full_scan = true) { // Une anal
 
             if (!file_exists($file_path)) {
                 if ($debug_mode) { error_log("  -> Image Cassée Trouvée : " . $image_url); }
+                $url_for_storage    = blc_prepare_url_for_storage($original_image_url);
+                $anchor_for_storage = blc_prepare_text_field_for_storage(basename($image_url));
                 $wpdb->insert(
                     $table_name,
                     [
-                        'url'        => $original_image_url,
-                        'anchor'     => basename($image_url),
+                        'url'        => $url_for_storage,
+                        'anchor'     => $anchor_for_storage,
                         'post_id'    => $post->ID,
-                        'post_title' => $post->post_title,
+                        'post_title' => $post_title_for_storage,
                         'type'       => 'image',
                     ],
                     ['%s', '%s', '%d', '%s', '%s']

--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -204,6 +204,8 @@ function blc_ajax_edit_link_callback() {
     $raw_old_url = $params['old_url'];
     $raw_new_url = $params['new_url'];
 
+    $stored_old_url = blc_prepare_url_for_storage($raw_old_url);
+
     $validated_old_url = wp_http_validate_url($raw_old_url);
     $normalized_old_url = $validated_old_url ?: blc_normalize_link_url($raw_old_url, $site_url, $site_scheme);
     $validated_new_url = wp_http_validate_url($raw_new_url);
@@ -265,7 +267,7 @@ function blc_ajax_edit_link_callback() {
     $table_name = $wpdb->prefix . 'blc_broken_links';
     $delete_result = $wpdb->delete(
         $table_name,
-        ['post_id' => $post_id, 'url' => $old_url, 'type' => 'link'],
+        ['post_id' => $post_id, 'url' => $stored_old_url, 'type' => 'link'],
         ['%d', '%s', '%s']
     );
 
@@ -303,6 +305,7 @@ function blc_ajax_unlink_callback() {
     }
 
     $raw_url_to_unlink = $params['url_to_unlink'];
+    $stored_url_to_unlink = blc_prepare_url_for_storage($raw_url_to_unlink);
     $validated_url = wp_http_validate_url($raw_url_to_unlink);
     $normalized_url = $validated_url ?: blc_normalize_link_url($raw_url_to_unlink, $site_url, $site_scheme);
 
@@ -369,7 +372,7 @@ function blc_ajax_unlink_callback() {
     $table_name = $wpdb->prefix . 'blc_broken_links';
     $delete_result = $wpdb->delete(
         $table_name,
-        ['post_id' => $post_id, 'url' => $url_to_unlink, 'type' => 'link'],
+        ['post_id' => $post_id, 'url' => $stored_url_to_unlink, 'type' => 'link'],
         ['%d', '%s', '%s']
     );
 


### PR DESCRIPTION
## Summary
- add helper utilities to trim and truncate URLs and text fields before persisting them
- ensure link and image scanners use the normalized values when inserting database records
- reuse the same truncation when editing or unlinking entries via AJAX so deletions target stored values

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68cadcaf3ff0832e8d87495f06471610