### PR TITLE
Allow storing long URLs and cover AJAX flows

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-utils.php
+++ b/liens-morts-detector-jlg/includes/blc-utils.php
@@ -101,16 +101,14 @@ function blc_truncate_for_storage($value, $max_length, $normalize_whitespace = f
 }
 
 /**
- * Prepare a URL for storage in the database by trimming and truncating it.
+ * Prepare a URL for storage in the database by trimming it.
  *
  * @param string $url Raw URL captured during the scan or provided by the UI.
  *
- * @return string URL cleaned to match the storage column length.
+ * @return string URL cleaned while preserving its full length.
  */
 function blc_prepare_url_for_storage($url) {
-    $max_length = defined('BLC_URL_MAX_LENGTH') ? (int) BLC_URL_MAX_LENGTH : 255;
-
-    return blc_truncate_for_storage($url, $max_length, false);
+    return blc_truncate_for_storage($url, 0, false);
 }
 
 /**


### PR DESCRIPTION
## Summary
- store broken link URLs in a LONGTEXT column and add a migration for existing installs
- stop truncating URLs before saving them and ensure the AJAX flows keep the full value
- add an end-to-end AJAX test that edits then unlinks a link whose URL is longer than 255 characters

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68cb01a7715c832e95a6e262837df7b0