### PR TITLE
Refine domain exclusion matching and add subdomain tests

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -332,7 +332,18 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
                     if ($domain_to_exclude === '') {
                         continue;
                     }
-                    if (substr($normalized_host, -strlen($domain_to_exclude)) === $domain_to_exclude) { $is_excluded = true; break; }
+
+                    if ($normalized_host === $domain_to_exclude) {
+                        $is_excluded = true;
+                        break;
+                    }
+
+                    $suffix = '.' . $domain_to_exclude;
+                    $suffix_length = strlen($suffix);
+                    if (strlen($normalized_host) > $suffix_length && substr($normalized_host, -$suffix_length) === $suffix) {
+                        $is_excluded = true;
+                        break;
+                    }
                 }
             }
 

--- a/tests/BlcScannerTest.php
+++ b/tests/BlcScannerTest.php
@@ -459,6 +459,44 @@ class BlcScannerTest extends TestCase
         $this->assertSame($this->utcNow, $this->updatedOptions['blc_last_check_time'] ?? null, 'Last check time should be updated.');
     }
 
+    public function test_blc_perform_check_excludes_subdomains_but_not_similar_domains(): void
+    {
+        global $wpdb;
+        $wpdb = $this->createWpdbStub();
+
+        $this->options['blc_excluded_domains'] = "example.com";
+        $this->options['blc_scan_method'] = 'precise';
+
+        $post = (object) [
+            'ID' => 21,
+            'post_title' => 'Subdomain Exclusion Post',
+            'post_content' => implode(' ', [
+                '<a href="http://example.com/page">Root Domain</a>',
+                '<a href="http://sub.example.com/page">Subdomain</a>',
+                '<a href="http://notexample.com/bad">Similar But Allowed</a>',
+            ]),
+        ];
+
+        $GLOBALS['wp_query_queue'][] = [
+            'posts' => [$post],
+            'max_num_pages' => 1,
+        ];
+
+        $this->setHttpResponse('GET', 'http://notexample.com/bad', ['response' => ['code' => 404]]);
+
+        blc_perform_check(0, false);
+
+        $this->assertCount(1, $this->httpRequests, 'Only the non-excluded host should trigger an HTTP request.');
+        $this->assertSame('http://notexample.com/bad', $this->httpRequests[0]['url']);
+
+        $this->assertCount(1, $wpdb->inserted, 'Only the non-excluded host should be recorded as broken.');
+        $insert = $wpdb->inserted[0];
+        $this->assertSame('http://notexample.com/bad', $insert['data']['url']);
+        $this->assertSame('link', $insert['data']['type']);
+        $this->assertSame([], $this->scheduledEvents, 'The scan should complete without scheduling another batch.');
+        $this->assertSame($this->utcNow, $this->updatedOptions['blc_last_check_time'] ?? null, 'Last check time should be updated at the end of the scan.');
+    }
+
     public function test_blc_perform_check_reschedules_when_server_load_is_high(): void
     {
         global $wpdb;


### PR DESCRIPTION
## Summary
- tighten the exclusion logic so hosts are ignored only when they exactly match or are proper subdomains of configured domains
- add a PHPUnit test to cover subdomain exclusions without skipping similarly named domains

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68cb0d6edb88832ea8142640627ea5b9