### PR TITLE
Handle zero row deletions as success

### DIFF
--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -271,7 +271,7 @@ function blc_ajax_edit_link_callback() {
         ['%d', '%s', '%s']
     );
 
-    if (!$delete_result || is_wp_error($delete_result)) {
+    if ($delete_result === false || is_wp_error($delete_result)) {
         $error_message = 'La suppression du lien dans la base de données a échoué.';
         if (is_wp_error($delete_result)) {
             $error_message .= ' ' . $delete_result->get_error_message();
@@ -376,7 +376,7 @@ function blc_ajax_unlink_callback() {
         ['%d', '%s', '%s']
     );
 
-    if (!$delete_result || is_wp_error($delete_result)) {
+    if ($delete_result === false || is_wp_error($delete_result)) {
         $error_message = 'La suppression du lien dans la base de données a échoué.';
         if (is_wp_error($delete_result)) {
             $error_message .= ' ' . $delete_result->get_error_message();


### PR DESCRIPTION
## Summary
- adjust AJAX callbacks to only treat database delete failures when `$wpdb->delete()` returns `false` or a `WP_Error`
- keep AJAX success response even when no rows are removed from the broken links table
- extend Brain Monkey tests to cover the case where the delete operation returns zero affected rows

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68cb0d6dc76c832e8437abf777006d2d