### PR TITLE
Adjust domain exclusion logic

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -329,10 +329,22 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
             $is_excluded = false;
             if (!empty($excluded_domains) && !empty($host)) {
                 foreach ($excluded_domains as $domain_to_exclude) {
+                    $domain_to_exclude = (string) $domain_to_exclude;
                     if ($domain_to_exclude === '') {
                         continue;
                     }
-                    if (substr($normalized_host, -strlen($domain_to_exclude)) === $domain_to_exclude) { $is_excluded = true; break; }
+
+                    if ($normalized_host === $domain_to_exclude) {
+                        $is_excluded = true;
+                        break;
+                    }
+
+                    $suffix = '.' . $domain_to_exclude;
+                    $suffix_length = strlen($suffix);
+                    if ($suffix_length > 1 && substr($normalized_host, -$suffix_length) === $suffix) {
+                        $is_excluded = true;
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary
- ensure excluded domains match only the exact host or real subdomains before skipping links
- add scanner test coverage verifying subdomains are skipped while similarly named domains continue to be scanned

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68cb0cf6fce4832e87cf9dab413c1b15