### PR TITLE
Handle overnight rest window for scanner

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -102,7 +102,14 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
 
     // --- 2. Contrôles pré-analyse ---
     $current_hour = (int) current_time('H');
-    if ($current_hour >= $rest_start_hour && $current_hour < $rest_end_hour && !$is_full_scan) {
+    $is_in_rest_window = false;
+    if ($rest_start_hour <= $rest_end_hour) {
+        $is_in_rest_window = ($current_hour >= $rest_start_hour && $current_hour < $rest_end_hour);
+    } else {
+        $is_in_rest_window = ($current_hour >= $rest_start_hour || $current_hour < $rest_end_hour);
+    }
+
+    if ($is_in_rest_window && !$is_full_scan) {
         if ($debug_mode) { error_log("Scan arrêté : dans la plage horaire de repos."); }
 
         $current_gmt_timestamp = time();


### PR DESCRIPTION
## Summary
- compute an explicit rest-window flag that handles overnight schedules in `blc_perform_check`
- reuse the shared flag when rescheduling a scan inside the configured rest period
- add a regression test ensuring scans scheduled at 23:00 with a 22:00–06:00 rest window are deferred without touching the database

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68cb2c3ac694832e86474f6cf66b9af2