### PR TITLE
Handle upload image queries when resolving paths

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -467,12 +467,14 @@ function blc_perform_image_check($batch = 0, $is_full_scan = true) { // Une anal
                 continue;
             }
 
-            $parsed_image_url = function_exists('wp_parse_url') ? wp_parse_url($image_url) : parse_url($image_url);
-            if (!is_array($parsed_image_url) || empty($parsed_image_url['path'])) {
+            $image_path_from_url = function_exists('wp_parse_url')
+                ? wp_parse_url($image_url, PHP_URL_PATH)
+                : parse_url($image_url, PHP_URL_PATH);
+            if (!is_string($image_path_from_url) || $image_path_from_url === '') {
                 continue;
             }
 
-            $image_path = wp_normalize_path($parsed_image_url['path']);
+            $image_path = wp_normalize_path($image_path_from_url);
 
             $parsed_upload_baseurl = function_exists('wp_parse_url') ? wp_parse_url($normalized_upload_baseurl) : parse_url($normalized_upload_baseurl);
             $upload_base_path = '';

--- a/tests/BlcScannerTest.php
+++ b/tests/BlcScannerTest.php
@@ -877,7 +877,8 @@ class BlcScannerTest extends TestCase
         $post = (object) [
             'ID' => 92,
             'post_title' => 'Uploads Image With Query',
-            'post_content' => '<img src="https://example.com/wp-content/uploads/2024/05/present.jpg?ver=123" />',
+            'post_content' => '<img src="https://example.com/wp-content/uploads/2024/05/present.jpg?ver=123" />'
+                . '<img src="https://example.com/wp-content/uploads/2024/05/missing-query.jpg?ver=456" />',
         ];
 
         $GLOBALS['wp_query_queue'][] = [
@@ -893,7 +894,14 @@ class BlcScannerTest extends TestCase
             @rmdir(dirname($image_dir));
         }
 
-        $this->assertCount(0, $wpdb->inserted, 'Existing upload with query string should not be flagged as broken.');
+        $this->assertCount(1, $wpdb->inserted, 'Only the missing upload should be flagged even when query strings are present.');
+        $insert = $wpdb->inserted[0];
+        $this->assertSame('image', $insert['data']['type']);
+        $this->assertSame('missing-query.jpg', $insert['data']['anchor']);
+        $this->assertSame(
+            'https://example.com/wp-content/uploads/2024/05/missing-query.jpg?ver=456',
+            $insert['data']['url']
+        );
     }
 
     public function test_blc_perform_image_check_ignores_traversal_urls(): void


### PR DESCRIPTION
## Summary
- derive the upload-relative path for image URLs from the parsed path component, ignoring any query or fragment
- ensure the stored filename for broken uploads is recomputed from the sanitized path segment
- extend the image scan test to cover uploads that include versioned query strings and confirm only missing assets are reported

## Testing
- ./vendor/bin/phpunit tests/BlcScannerTest.php


------
https://chatgpt.com/codex/tasks/task_e_68cb2c3919c8832ea04c7676864f021b