### PR TITLE
Nettoyage des liens orphelins et gestion des posts supprimés

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -238,6 +238,9 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
     $wp_query = new WP_Query($args);
     $posts = $wp_query->posts;
 
+    $cleanup_sql = "DELETE blc FROM $table_name AS blc LEFT JOIN {$wpdb->posts} AS posts ON blc.post_id = posts.ID WHERE blc.type = %s AND posts.ID IS NULL";
+    $wpdb->query($wpdb->prepare($cleanup_sql, 'link'));
+
     $post_ids_in_batch = wp_list_pluck($posts, 'ID');
     if (!empty($post_ids_in_batch)) {
         $post_ids_in_batch = array_map('intval', $post_ids_in_batch);


### PR DESCRIPTION
## Résumé
- nettoie la table des liens brisés en supprimant les entrées orphelines avant chaque insertion
- ajuste les callbacks AJAX pour réussir quand l’article référencé a été supprimé et purger la base
- enrichit la couverture de tests PHPUnit pour les nouveaux scénarios et met à jour les stubs WPDB

## Tests
- `vendor/bin/phpunit --bootstrap vendor/autoload.php tests`


------
https://chatgpt.com/codex/tasks/task_e_68cc6daa1adc832e9930e25b99c49f9a