### PR TITLE
Force full scans for scheduled link checks

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -90,6 +90,11 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
     // --- 1. Récupération des réglages ---
     $debug_mode = get_option('blc_debug_mode', false);
     if ($debug_mode) { error_log("--- Début du scan LIENS (Lot #$batch) ---"); }
+
+    $current_hook = function_exists('current_filter') ? current_filter() : '';
+    if (!$is_full_scan && $current_hook === 'blc_check_links') {
+        $is_full_scan = true;
+    }
     
     $rest_start_hour_option = get_option('blc_rest_start_hour', '08');
     $rest_end_hour_option   = get_option('blc_rest_end_hour', '20');


### PR DESCRIPTION
## Summary
- ensure scans triggered from the recurring `blc_check_links` hook always run in full-scan mode
- keep manual partial scans unchanged by only overriding the cron-driven executions

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68cc6da94d10832eabb3eace727fc740