### PR TITLE
Handle missing load averages from sys_getloadavg

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -202,17 +202,23 @@ function blc_perform_check($batch = 0, $is_full_scan = false) {
     if (function_exists('sys_getloadavg')) {
         $load_values = sys_getloadavg();
 
-        if (is_array($load_values) && isset($load_values[0]) && is_numeric($load_values[0])) {
-            $current_load = (float) $load_values[0];
-            $max_load_threshold = (float) apply_filters('blc_max_load_threshold', 2.0);
+        if (is_array($load_values) && !empty($load_values)) {
+            $current_load = reset($load_values);
 
-            if ($max_load_threshold > 0 && $current_load > $max_load_threshold) {
-                $retry_delay = (int) apply_filters('blc_load_retry_delay', 300);
-                if ($retry_delay < 0) { $retry_delay = 0; }
+            if (is_numeric($current_load)) {
+                $current_load = (float) $current_load;
+                $max_load_threshold = (float) apply_filters('blc_max_load_threshold', 2.0);
 
-                if ($debug_mode) { error_log("Scan reporté : charge serveur trop élevée (" . $current_load . ")."); }
-                wp_schedule_single_event(time() + $retry_delay, 'blc_check_batch', array($batch, $is_full_scan));
-                return;
+                if ($max_load_threshold > 0 && $current_load > $max_load_threshold) {
+                    $retry_delay = (int) apply_filters('blc_load_retry_delay', 300);
+                    if ($retry_delay < 0) { $retry_delay = 0; }
+
+                    if ($debug_mode) { error_log("Scan reporté : charge serveur trop élevée (" . $current_load . ")."); }
+                    wp_schedule_single_event(time() + $retry_delay, 'blc_check_batch', array($batch, $is_full_scan));
+                    return;
+                }
+            } elseif ($debug_mode) {
+                error_log('Contrôle de charge ignoré : la première valeur retournée par sys_getloadavg() n\'est pas numérique.');
             }
         } elseif ($debug_mode) {
             error_log('Contrôle de charge ignoré : sys_getloadavg() n\'a pas retourné de données valides.');


### PR DESCRIPTION
## Summary
- harden the sys_getloadavg handling in blc_perform_check by verifying the returned data before using it
- keep existing rescheduling logic while logging when load averages are unavailable or invalid

## Testing
- php -l liens-morts-detector-jlg/includes/blc-scanner.php

------
https://chatgpt.com/codex/tasks/task_e_68cd75d33f3c832ea90607529f336ad2