### PR TITLE
Respect rest window bypass flag for link scans

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -55,8 +55,9 @@ function blc_dashboard_links_page() {
     if (isset($_POST['blc_manual_check'])) {
         check_admin_referer('blc_manual_check_nonce');
         $is_full = isset($_POST['blc_full_scan']);
+        $bypass_rest_window = $is_full;
         wp_clear_scheduled_hook('blc_check_batch');
-        wp_schedule_single_event(time(), 'blc_check_batch', array(0, $is_full));
+        wp_schedule_single_event(time(), 'blc_check_batch', array(0, $is_full, $bypass_rest_window));
         printf(
             '<div class="notice notice-success is-dismissible"><p>%s</p></div>',
             esc_html__("La vérification des liens a été programmée et s'exécute en arrière-plan.", 'liens-morts-detector-jlg')

--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -45,7 +45,7 @@ add_filter('cron_schedules', 'blc_add_cron_schedules');
 
 // Lie nos fonctions de scan aux tâches planifiées
 add_action('blc_check_links', 'blc_perform_check');
-add_action('blc_check_batch', 'blc_perform_check', 10, 2);
+add_action('blc_check_batch', 'blc_perform_check', 10, 3);
 add_action('blc_check_image_batch', 'blc_perform_image_check', 10, 2);
 
 // Ajoute nos fichiers CSS et JS dans l'administration


### PR DESCRIPTION
## Summary
- add an explicit $bypass_rest_window flag to the link scanner and ensure it is propagated to subsequent batches
- update manual scheduling and hook registration to pass along the bypass flag only for intentional full scans
- extend scanner unit tests to cover bypass behaviour and the new argument list for scheduled batches

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68cda8e6b534832e9d69a7827de615b3