### PR TITLE
Fix internal link detection for protocol-relative URLs

### DIFF
--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -252,8 +252,8 @@ class BLC_Links_List_Table extends WP_List_Table {
         }
 
         $patterns['relative'] = [
-            'sql'    => 'url LIKE %s',
-            'params' => ['/%'],
+            'sql'    => '(url LIKE %s AND url NOT LIKE %s)',
+            'params' => ['/%', '//%'],
         ];
 
         $patterns['path_without_scheme'] = [


### PR DESCRIPTION
## Summary
- restrict the relative URL filter to paths that do not start with a double slash
- keep the inverse filter aligned so protocol-relative URLs are treated as external links

## Testing
- composer install
- ./vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68ce6ca0e350832ea8017c8bc68de49a