### PR TITLE
Allow editing links with relative targets

### DIFF
--- a/tests/BlcScannerTest.php
+++ b/tests/BlcScannerTest.php
@@ -116,6 +116,20 @@ class BlcScannerTest extends TestCase
 
             return preg_replace('#^[a-z0-9+.-]+://#i', $scheme . '://', $url);
         });
+        Functions\when('wp_kses_bad_protocol')->alias(function ($string, $allowed_protocols = []) {
+            $string = (string) $string;
+            $allowed_protocols = array_map('strtolower', (array) $allowed_protocols);
+
+            if (preg_match('#^([a-z0-9+.-]+):#i', $string, $matches)) {
+                $scheme = strtolower($matches[1]);
+
+                if (!in_array($scheme, $allowed_protocols, true)) {
+                    return preg_replace('#^[a-z0-9+.-]+:#i', '', $string);
+                }
+            }
+
+            return $string;
+        });
         $testCase = $this;
         Functions\when('current_time')->alias(function (string $type, $gmt = 0) use ($testCase) {
             if ($type === 'timestamp') {


### PR DESCRIPTION
## Summary
- update the AJAX edit handler to accept relative targets after normalizing them to HTTP/HTTPS URLs
- keep the author-provided href value while rejecting dangerous protocols
- cover relative link edits and protocol rejection in the AJAX callback tests and stub the new sanitizer in scanner tests

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68ce6d98a248832eb2dd3f72a0d0e9d0