### PR TITLE
Allow CDN hosts for image checks

### DIFF
--- a/tests/AdminListTablesTest.php
+++ b/tests/AdminListTablesTest.php
@@ -114,13 +114,13 @@ class AdminListTablesTest extends TestCase
         $this->assertStringContainsString("(url LIKE 'https://example.com%')", $wpdb->last_get_var_query);
         $this->assertStringContainsString("(url LIKE 'http://example.com%')", $wpdb->last_get_var_query);
         $this->assertStringContainsString("(url LIKE '//example.com%')", $wpdb->last_get_var_query);
-        $this->assertStringContainsString("(url LIKE '/%')", $wpdb->last_get_var_query);
+        $this->assertStringContainsString("(url LIKE '/%' AND url NOT LIKE '//%')", $wpdb->last_get_var_query);
         $this->assertStringContainsString("(url NOT LIKE '%://%' AND url NOT LIKE '//%' AND url NOT LIKE '%:%'", $wpdb->last_get_var_query);
 
         $this->assertStringContainsString("(url LIKE 'https://example.com%')", $wpdb->last_get_results_query);
         $this->assertStringContainsString("(url LIKE 'http://example.com%')", $wpdb->last_get_results_query);
         $this->assertStringContainsString("(url LIKE '//example.com%')", $wpdb->last_get_results_query);
-        $this->assertStringContainsString("(url LIKE '/%')", $wpdb->last_get_results_query);
+        $this->assertStringContainsString("(url LIKE '/%' AND url NOT LIKE '//%')", $wpdb->last_get_results_query);
         $this->assertStringContainsString("(url NOT LIKE '%://%' AND url NOT LIKE '//%' AND url NOT LIKE '%:%'", $wpdb->last_get_results_query);
     }
 
@@ -139,13 +139,13 @@ class AdminListTablesTest extends TestCase
         $this->assertStringContainsString("NOT (url LIKE 'https://example.com%')", $wpdb->last_get_var_query);
         $this->assertStringContainsString("NOT (url LIKE 'http://example.com%')", $wpdb->last_get_var_query);
         $this->assertStringContainsString("NOT (url LIKE '//example.com%')", $wpdb->last_get_var_query);
-        $this->assertStringContainsString("NOT (url LIKE '/%')", $wpdb->last_get_var_query);
+        $this->assertStringContainsString("NOT ((url LIKE '/%' AND url NOT LIKE '//%'))", $wpdb->last_get_var_query);
         $this->assertStringContainsString("NOT ((url NOT LIKE '%://%' AND url NOT LIKE '//%' AND url NOT LIKE '%:%'", $wpdb->last_get_var_query);
 
         $this->assertStringContainsString("NOT (url LIKE 'https://example.com%')", $wpdb->last_get_results_query);
         $this->assertStringContainsString("NOT (url LIKE 'http://example.com%')", $wpdb->last_get_results_query);
         $this->assertStringContainsString("NOT (url LIKE '//example.com%')", $wpdb->last_get_results_query);
-        $this->assertStringContainsString("NOT (url LIKE '/%')", $wpdb->last_get_results_query);
+        $this->assertStringContainsString("NOT ((url LIKE '/%' AND url NOT LIKE '//%'))", $wpdb->last_get_results_query);
         $this->assertStringContainsString("NOT ((url NOT LIKE '%://%' AND url NOT LIKE '//%' AND url NOT LIKE '%:%'", $wpdb->last_get_results_query);
         $this->assertStringContainsString('url IS NULL', $wpdb->last_get_results_query);
         $this->assertStringContainsString("url = ''", $wpdb->last_get_results_query);


### PR DESCRIPTION
## Summary
- allow the image scanner to trust both the site host and the uploads base URL when whitelisting hosts
- update list table tests to reflect the stricter relative upload condition
- add coverage ensuring missing CDN-hosted uploads are detected

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68ce7439d8c4832ea6b7f4cc12e090f7