### PR TITLE
Normalize edited links before updating href

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -37,6 +37,29 @@ function blc_normalize_link_url($url, $site_url, $site_scheme = null) {
 
     $site_url = rtrim((string) $site_url, '/') . '/';
 
+    $trimmed_url = ltrim($url);
+    $authority_candidate = $trimmed_url;
+    $slash_position = strpos($trimmed_url, '/');
+    if ($slash_position !== false) {
+        $authority_candidate = substr($trimmed_url, 0, $slash_position);
+    }
+
+    if (
+        $authority_candidate !== '' &&
+        strpos($authority_candidate, '.') !== false &&
+        preg_match('/^[A-Za-z0-9][A-Za-z0-9.-]*(?::[0-9]+)?$/', $authority_candidate) === 1
+    ) {
+        $last_dot = strrpos($authority_candidate, '.');
+        $tld = $last_dot !== false ? substr($authority_candidate, $last_dot + 1) : '';
+
+        if ($tld !== '' && preg_match('/^[A-Za-z]{2,}$/', $tld) === 1) {
+            $scheme = ($site_scheme !== null && $site_scheme !== '') ? $site_scheme : 'http';
+            $remaining = substr($trimmed_url, strlen($authority_candidate));
+
+            return $scheme . '://' . $authority_candidate . $remaining;
+        }
+    }
+
     if (isset($parsed_url['path']) && strpos($parsed_url['path'], '/') === 0) {
         $base = rtrim($site_url, '/');
         return $base . $url;

--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -245,6 +245,22 @@ function blc_ajax_edit_link_callback() {
         wp_send_json_error(['message' => 'URL invalide.']);
     }
 
+    $final_new_url = $prepared_new_url;
+    $is_explicit_new_url = (
+        preg_match('#^https?://#i', $prepared_new_url) === 1 ||
+        strpos($prepared_new_url, '//') === 0 ||
+        strpos($prepared_new_url, '/') === 0 ||
+        strpos($prepared_new_url, '#') === 0
+    );
+
+    if (!$is_explicit_new_url) {
+        if (!$validated_new_url || $normalized_new_url === '') {
+            wp_send_json_error(['message' => 'URL invalide.']);
+        }
+
+        $final_new_url = $normalized_new_url;
+    }
+
     $post = get_post($post_id);
     if (!$post) {
         $wpdb->delete(
@@ -262,7 +278,7 @@ function blc_ajax_edit_link_callback() {
     }
 
     $old_url = $prepared_old_url;
-    $new_url = $prepared_new_url;
+    $new_url = $final_new_url;
 
     $dom_data = blc_load_dom_from_post($post->post_content);
     if (isset($dom_data['error'])) {

--- a/tests/BlcAjaxCallbacksTest.php
+++ b/tests/BlcAjaxCallbacksTest.php
@@ -307,6 +307,61 @@ class BlcAjaxCallbacksTest extends TestCase
         $this->assertSame(['%d', '%s', '%s'], $wpdb->delete_args[2]);
     }
 
+    public function test_edit_link_normalizes_bare_domain_for_href(): void
+    {
+        $_POST['post_id'] = 43;
+        $_POST['old_url'] = 'http://old.com';
+        $_POST['new_url'] = 'www.example.com';
+
+        Functions\when('check_ajax_referer')->justReturn(true);
+        Functions\expect('current_user_can')->once()->with('edit_post', 43)->andReturn(true);
+
+        $post = (object) ['post_content' => '<a href="http://old.com">Ancien lien</a>'];
+        Functions\expect('get_post')->once()->with(43)->andReturn($post);
+
+        $captured_update = null;
+        Functions\expect('wp_update_post')->once()->andReturnUsing(function () use (&$captured_update) {
+            $captured_update = func_get_args();
+            return true;
+        });
+
+        global $wpdb;
+        $wpdb = new class {
+            public $prefix = '';
+            public $delete_args = null;
+            public function delete($table, $where, $formats)
+            {
+                $this->delete_args = [$table, $where, $formats];
+
+                return true;
+            }
+        };
+
+        Functions\expect('wp_send_json_success')->once()->andReturnUsing(function () {
+            throw new \Exception('success');
+        });
+
+        try {
+            blc_ajax_edit_link_callback();
+            $this->fail('wp_send_json_success was not called');
+        } catch (\Exception $exception) {
+            $this->assertSame('success', $exception->getMessage());
+        }
+
+        $this->assertIsArray($captured_update);
+        $this->assertCount(2, $captured_update);
+        $this->assertIsArray($captured_update[0]);
+        $this->assertSame(43, $captured_update[0]['ID']);
+        $this->assertStringContainsString('<a href="https://www.example.com">', $captured_update[0]['post_content']);
+        $this->assertStringNotContainsString('<a href="www.example.com">', $captured_update[0]['post_content']);
+        $this->assertStringNotContainsString('http://old.com', $captured_update[0]['post_content']);
+
+        $this->assertIsArray($wpdb->delete_args);
+        $this->assertSame('blc_broken_links', $wpdb->delete_args[0]);
+        $this->assertSame(['post_id' => 43, 'url' => 'http://old.com', 'type' => 'link'], $wpdb->delete_args[1]);
+        $this->assertSame(['%d', '%s', '%s'], $wpdb->delete_args[2]);
+    }
+
     public function test_edit_link_rejects_dangerous_scheme(): void
     {
         $_POST['post_id'] = 8;


### PR DESCRIPTION
## Summary
- ensure AJAX link edits keep explicit URLs untouched and fall back to validated normalized values for implicit inputs
- extend link normalization to treat bare domain inputs as HTTPS URLs while keeping relative URLs intact
- add a regression test covering an edit with `www.example.com`

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68ce8a21831c832eaacdfc8a470897cf