### PR TITLE
Sanitize edit links in admin list tables

### DIFF
--- a/liens-morts-detector-jlg/includes/class-blc-images-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-images-list-table.php
@@ -57,14 +57,26 @@ class BLC_Images_List_Table extends WP_List_Table {
      * Gère le rendu de la colonne "Trouvé dans...".
      */
     protected function column_post_title($item) {
-        return sprintf('<a href="%s">%s</a>', get_edit_post_link($item['post_id']), esc_html($item['post_title']));
+        $edit_link = get_edit_post_link($item['post_id']);
+
+        if ($edit_link === false) {
+            return '&mdash;';
+        }
+
+        return sprintf('<a href="%s">%s</a>', esc_url($edit_link), esc_html($item['post_title']));
     }
 
     /**
      * Gère le rendu de la colonne "Actions".
      */
     protected function column_actions($item) {
-        return sprintf('<a href="%s" class="button button-secondary">Modifier l\'article</a>', get_edit_post_link($item['post_id']));
+        $edit_link = get_edit_post_link($item['post_id']);
+
+        if ($edit_link === false) {
+            return '&mdash;';
+        }
+
+        return sprintf('<a href="%s" class="button button-secondary">Modifier l\'article</a>', esc_url($edit_link));
     }
 
     /**

--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -113,14 +113,26 @@ class BLC_Links_List_Table extends WP_List_Table {
      * Gère le rendu de la colonne "Trouvé dans...".
      */
     protected function column_post_title($item) {
-        return sprintf('<a href="%s">%s</a>', get_edit_post_link($item['post_id']), esc_html($item['post_title']));
+        $edit_link = get_edit_post_link($item['post_id']);
+
+        if ($edit_link === false) {
+            return '&mdash;';
+        }
+
+        return sprintf('<a href="%s">%s</a>', esc_url($edit_link), esc_html($item['post_title']));
     }
 
     /**
      * Gère le rendu de la colonne "Actions".
      */
     protected function column_actions($item) {
-        return sprintf('<a href="%s" class="button button-secondary">Modifier l\'article</a>', get_edit_post_link($item['post_id']));
+        $edit_link = get_edit_post_link($item['post_id']);
+
+        if ($edit_link === false) {
+            return '&mdash;';
+        }
+
+        return sprintf('<a href="%s" class="button button-secondary">Modifier l\'article</a>', esc_url($edit_link));
     }
 
     /**


### PR DESCRIPTION
## Summary
- reuse the edit link value in link and image list table columns
- handle missing edit links by displaying an em dash
- escape edit link URLs before rendering anchor tags

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68ce8f479fb4832eabba7b0f27bed10e