### PR TITLE
Track last image scan completion

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -173,12 +173,14 @@ function blc_dashboard_images_page() {
             'image'
         )
     );
-    $last_check_time     = get_option('blc_last_check_time', 0);
+    $last_image_check_time = get_option('blc_last_image_check_time', 0);
     $option_size_kb      = $option_size_bytes / 1024;
     $size_display        = ($option_size_kb < 1024)
         ? sprintf('%s %s', number_format_i18n($option_size_kb, 2), __('Ko', 'liens-morts-detector-jlg'))
         : sprintf('%s %s', number_format_i18n($option_size_kb / 1024, 2), __('Mo', 'liens-morts-detector-jlg'));
-    $last_check_display  = $last_check_time ? date_i18n('j M Y', $last_check_time) : __('Jamais', 'liens-morts-detector-jlg');
+    $last_check_display  = $last_image_check_time
+        ? date_i18n('j M Y', $last_image_check_time)
+        : __('Jamais', 'liens-morts-detector-jlg');
 
     $list_table = new BLC_Images_List_Table();
     $list_table->prepare_items();
@@ -196,7 +198,7 @@ function blc_dashboard_images_page() {
              </div>
              <div class="blc-stat">
                  <span class="blc-stat-value"><?php echo esc_html($last_check_display); ?></span>
-                 <span class="blc-stat-label"><?php esc_html_e('Dernière analyse de liens', 'liens-morts-detector-jlg'); ?></span>
+                 <span class="blc-stat-label"><?php esc_html_e('Dernière analyse d\'images', 'liens-morts-detector-jlg'); ?></span>
              </div>
         </div>
         <form method="post" style="margin-bottom: 20px;">

--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -616,5 +616,6 @@ function blc_perform_image_check($batch = 0, $is_full_scan = true) { // Une anal
         wp_schedule_single_event(time() + 60, 'blc_check_image_batch', array($batch + 1, true));
     } else {
         if ($debug_mode) { error_log("--- Scan IMAGES terminé ---"); }
+        update_option('blc_last_image_check_time', time());
     }
 }

--- a/liens-morts-detector-jlg/uninstall.php
+++ b/liens-morts-detector-jlg/uninstall.php
@@ -9,6 +9,7 @@ if (!defined('WP_UNINSTALL_PLUGIN')) {
 // (les liens et images brisés sont stockés dans une table dédiée)
 $options_to_delete = [
     'blc_last_check_time',
+    'blc_last_image_check_time',
     'blc_frequency',
     'blc_rest_start_hour',
     'blc_rest_end_hour',


### PR DESCRIPTION
## Summary
- record the completion time of image scan batches
- display the last image scan date in the images dashboard using the new option and adjust the label
- remove the stored image scan timestamp when uninstalling the plugin

## Testing
- `php -l liens-morts-detector-jlg/includes/blc-scanner.php`
- `php -l liens-morts-detector-jlg/includes/blc-admin-pages.php`
- `php -l liens-morts-detector-jlg/uninstall.php`


------
https://chatgpt.com/codex/tasks/task_e_68cf4122b968832ea38cc567a46b20ea