### PR TITLE
Handle blog charset when loading DOM content

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-utils.php
+++ b/liens-morts-detector-jlg/includes/blc-utils.php
@@ -19,8 +19,20 @@ function blc_load_dom_from_post($post_content) {
 
     $dom = new DOMDocument();
 
+    $source_charset = 'UTF-8';
+    if (function_exists('get_bloginfo')) {
+        $blog_charset = get_bloginfo('charset');
+        if (is_string($blog_charset)) {
+            $blog_charset = trim($blog_charset);
+        }
+
+        if (!empty($blog_charset)) {
+            $source_charset = $blog_charset;
+        }
+    }
+
     if (function_exists('mb_convert_encoding')) {
-        $converted_content = mb_convert_encoding($post_content, 'HTML-ENTITIES', 'UTF-8');
+        $converted_content = mb_convert_encoding($post_content, 'HTML-ENTITIES', $source_charset);
         if ($converted_content === false) {
             $converted_content = $post_content;
         }


### PR DESCRIPTION
## Summary
- retrieve the blog charset before converting post content for DOM loading and fall back to UTF-8
- stub get_bloginfo in AJAX callback tests and cover non-UTF-8 charsets to ensure AJAX flows continue to work

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68cfef267d50832ea88f067ab402eced