### PR TITLE
Ensure internal link detection enforces domain boundaries

### DIFF
--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -250,9 +250,16 @@ class BLC_Links_List_Table extends WP_List_Table {
             }
 
             if (!isset($patterns[$value])) {
+                $regex_value = preg_quote($value, '/');
+                $regex_value = str_replace('\/', '/', $regex_value);
+                $regex_value = str_replace('\:', ':', $regex_value);
+
                 $patterns[$value] = [
-                    'sql'    => 'url LIKE %s',
-                    'params' => [$wpdb->esc_like($value) . '%'],
+                    'sql'    => '(url LIKE %s AND url REGEXP %s)',
+                    'params' => [
+                        $wpdb->esc_like($value) . '%',
+                        '^' . $regex_value . '(?:[/?#]|$)',
+                    ],
                 ];
             }
         };


### PR DESCRIPTION
## Summary
- update the internal URL detection patterns to pair LIKE conditions with boundary-aware REGEXP checks
- adjust the negative SQL logic to mirror the stricter internal matching and add coverage for lookalike URLs
- extend the admin list table tests to assert the new SQL fragments and verify that lookalike domains are treated as external

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68cff9751c58832eb577174c8cd5bd5c