### PR TITLE
Handle case-insensitive upload matching

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -585,7 +585,11 @@ function blc_perform_image_check($batch = 0, $is_full_scan = true) { // Une anal
                 $normalized_upload_baseurl = set_url_scheme($upload_baseurl, $image_scheme);
             }
 
-            if (strpos($image_url, $normalized_upload_baseurl) !== 0) {
+            $normalized_upload_baseurl_length = strlen($normalized_upload_baseurl);
+            if (
+                $normalized_upload_baseurl_length === 0 ||
+                strncasecmp($image_url, $normalized_upload_baseurl, $normalized_upload_baseurl_length) !== 0
+            ) {
                 continue;
             }
 
@@ -605,13 +609,17 @@ function blc_perform_image_check($batch = 0, $is_full_scan = true) { // Une anal
             }
 
             $upload_base_path_trimmed = ltrim(trailingslashit($upload_base_path), '/');
+            $upload_base_path_trimmed_length = strlen($upload_base_path_trimmed);
             $image_path_trimmed = ltrim($image_path, '/');
 
-            if ($upload_base_path_trimmed === '' || strpos($image_path_trimmed, $upload_base_path_trimmed) !== 0) {
+            if (
+                $upload_base_path_trimmed_length === 0 ||
+                strncasecmp($image_path_trimmed, $upload_base_path_trimmed, $upload_base_path_trimmed_length) !== 0
+            ) {
                 continue;
             }
 
-            $relative_path = ltrim(substr($image_path_trimmed, strlen($upload_base_path_trimmed)), '/');
+            $relative_path = ltrim(substr($image_path_trimmed, $upload_base_path_trimmed_length), '/');
             if ($relative_path === '') {
                 continue;
             }


### PR DESCRIPTION
## Summary
- make the image upload prefix detection tolerant to uppercase URL variants
- add coverage for uppercase upload URLs to ensure missing images are still reported and existing ones are left alone

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d045c253d8832e8e28f75a3ed3c556