### PR TITLE
Normalize relative links using permalink context

### DIFF
--- a/tests/BlcAjaxCallbacksTest.php
+++ b/tests/BlcAjaxCallbacksTest.php
@@ -527,6 +527,8 @@ class BlcAjaxCallbacksTest extends TestCase
 
         Functions\when('check_ajax_referer')->justReturn(true);
 
+        Functions\expect('get_post')->once()->with(8)->andReturn(null);
+
         global $wpdb;
         $wpdb = new class {
             public $prefix = 'wp_';

--- a/tests/BlcScannerTest.php
+++ b/tests/BlcScannerTest.php
@@ -397,6 +397,28 @@ class BlcScannerTest extends TestCase
         );
     }
 
+    public function test_blc_perform_check_resolves_relative_links_using_permalink(): void
+    {
+        global $wpdb;
+        $wpdb = $this->createWpdbStub();
+
+        $post = (object) [
+            'ID' => 321,
+            'post_title' => 'Relative Link',
+            'post_content' => '<a href="section/page.html">Link</a>',
+        ];
+
+        $GLOBALS['wp_query_queue'][] = [
+            'posts' => [$post],
+            'max_num_pages' => 0,
+        ];
+
+        blc_perform_check(0, false);
+
+        $this->assertNotEmpty($this->httpRequests, 'Relative links should trigger an HTTP request with the resolved URL.');
+        $this->assertSame('https://example.com/post-321/section/page.html', $this->httpRequests[0]['url']);
+    }
+
     public function test_blc_perform_check_delays_during_rest_period(): void
     {
         global $wpdb;


### PR DESCRIPTION
## Summary
- update link normalization to derive origins from the document permalink with a home_url fallback
- pass the current permalink into scan and AJAX edit flows while keeping user-facing hrefs when they are truly relative
- expand unit tests to cover relative path resolution and domain handling during link edits

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d0595b9b6c832e9070f1431c20fd87