### PR TITLE
Allow scanning of internal hosts resolving to private IPs

### DIFF
--- a/patchwork.json
+++ b/patchwork.json
@@ -1,6 +1,8 @@
 {
     "redefinable-internals": [
         "sys_getloadavg",
-        "time"
+        "time",
+        "dns_get_record",
+        "gethostbynamel"
     ]
 }


### PR DESCRIPTION
## Summary
- collect trusted internal hosts from the site configuration during link scans
- only run the remote host safety gate for external domains to avoid skipping local content
- extend the test suite to cover internal hosts resolving to private IPs and allow DNS functions to be stubbed

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d05f864a8c832e8b53e45d3eada838