### PR TITLE
Normalize link URLs in admin list table

### DIFF
--- a/tests/BlcAjaxCallbacksTest.php
+++ b/tests/BlcAjaxCallbacksTest.php
@@ -30,6 +30,17 @@ class BlcAjaxCallbacksTest extends TestCase
         Functions\when('trailingslashit')->alias(function ($value) {
             return rtrim((string) $value, "\\/\t\n\r\f ") . '/';
         });
+        Functions\when('get_permalink')->alias(static function ($post = null) {
+            if (is_object($post) && isset($post->ID)) {
+                return sprintf('https://example.com/post/%d/', $post->ID);
+            }
+
+            if (is_numeric($post)) {
+                return sprintf('https://example.com/post/%d/', (int) $post);
+            }
+
+            return 'https://example.com/post/0/';
+        });
         Functions\when('set_url_scheme')->alias(function ($url, $scheme = null) {
             $scheme = $scheme ?: 'http';
 


### PR DESCRIPTION
## Summary
- ensure the admin broken links table normalizes link hrefs against the post permalink and site URL
- cover relative link normalization with a dedicated table test and stub WordPress helpers used during ajax tests

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d14cda2ba4832e92a715a145c06b39