### PR TITLE
Use WordPress timestamps for scan completion times

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -725,7 +725,7 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
     if ($wp_query->max_num_pages > ($batch + 1)) {
         wp_schedule_single_event(time() + $batch_delay_s, 'blc_check_batch', array($batch + 1, $is_full_scan, $bypass_rest_window));
     } else {
-        update_option('blc_last_check_time', time());
+        update_option('blc_last_check_time', current_time('timestamp'));
     }
 
     if ($debug_mode) { error_log("--- Fin du scan LIENS (Lot #$batch) ---"); }
@@ -899,6 +899,6 @@ function blc_perform_image_check($batch = 0, $is_full_scan = true) { // Une anal
         wp_schedule_single_event(time() + 60, 'blc_check_image_batch', array($batch + 1, true));
     } else {
         if ($debug_mode) { error_log("--- Scan IMAGES terminé ---"); }
-        update_option('blc_last_image_check_time', time());
+        update_option('blc_last_image_check_time', current_time('timestamp'));
     }
 }


### PR DESCRIPTION
## Summary
- update the scanner to record scan completion timestamps using WordPress' current_time helper for both link and image checks

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d16d89e3d0832ebb63b0a7383719b2