### PR TITLE
Use UTC timestamps for link scans

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -786,7 +786,7 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
     if ($wp_query->max_num_pages > ($batch + 1)) {
         wp_schedule_single_event(time() + $batch_delay_s, 'blc_check_batch', array($batch + 1, $is_full_scan, $bypass_rest_window));
     } else {
-        update_option('blc_last_check_time', current_time('timestamp'));
+        update_option('blc_last_check_time', time());
     }
 
     if ($debug_mode) { error_log("--- Fin du scan LIENS (Lot #$batch) ---"); }


### PR DESCRIPTION
## Summary
- store `blc_last_check_time` using `time()` so the saved value is UTC-compatible
- refine test stubs to respect timezone offsets and filter mocked queries by `post_modified_gmt`
- add a regression test ensuring incremental scans pick up posts modified shortly after the previous run when a timezone offset exists

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d2833db650832ebc5bc27af0cc5e9c