### PR TITLE
Prevent HTTP requests to unsafe remote hosts

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -673,7 +673,8 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
             if ($is_excluded) { continue; }
 
             $is_internal_safe_host = isset($safe_internal_hosts[$normalized_host]);
-            $is_safe_remote_host = true;
+            $is_safe_remote_host   = true;
+            $should_skip_remote_request = false;
 
             if (!$is_internal_safe_host) {
                 $is_safe_remote_host = blc_is_safe_remote_host($host);
@@ -691,8 +692,13 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
                         ],
                         ['%s', '%s', '%d', '%s', '%s']
                     );
-                    continue;
+                    $should_skip_remote_request = true;
                 }
+            }
+
+            if ($should_skip_remote_request) {
+                usleep($link_delay_ms * 1000);
+                continue;
             }
 
             $head_request_args = [

--- a/tests/BlcScannerTest.php
+++ b/tests/BlcScannerTest.php
@@ -648,7 +648,7 @@ class BlcScannerTest extends TestCase
         $this->assertSame('link', $insert['data']['type']);
     }
 
-    public function test_blc_perform_check_records_unsafe_external_hosts_without_http_requests(): void
+    public function test_blc_perform_check_records_domain_without_ip_without_http_requests(): void
     {
         global $wpdb;
         $wpdb = $this->createWpdbStub();
@@ -692,6 +692,7 @@ class BlcScannerTest extends TestCase
         $insert = $wpdb->inserted[0];
         $this->assertSame('wp_blc_broken_links', $insert['table']);
         $this->assertSame('http://no-ip.test/missing', $insert['data']['url']);
+        $this->assertSame('Broken', $insert['data']['anchor']);
         $this->assertSame('link', $insert['data']['type']);
         $this->assertSame(501, $insert['data']['post_id']);
     }


### PR DESCRIPTION
## Summary
- mark unsafe external hosts as broken immediately, record them in the broken links table, and skip outbound HTTP requests
- extend the scanner test suite to cover domains without DNS answers and assert the stored link metadata

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d2cacb3f00832ea83be73be597f4e0