### PR TITLE
Convert dashboard date to local timezone

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -86,7 +86,9 @@ function blc_dashboard_links_page() {
     $size_display       = ($option_size_kb < 1024)
         ? sprintf('%s %s', number_format_i18n($option_size_kb, 2), __('Ko', 'liens-morts-detector-jlg'))
         : sprintf('%s %s', number_format_i18n($option_size_kb / 1024, 2), __('Mo', 'liens-morts-detector-jlg'));
-    $last_check_display = $last_check_time ? date_i18n('j M Y', $last_check_time) : __('Jamais', 'liens-morts-detector-jlg');
+    $last_check_display = $last_check_time
+        ? wp_date('j M Y', $last_check_time)
+        : __('Jamais', 'liens-morts-detector-jlg');
 
     $list_table = new BLC_Links_List_Table();
     $list_table->prepare_items();

--- a/tests/BlcDashboardLinksPageTest.php
+++ b/tests/BlcDashboardLinksPageTest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace {
+    require_once __DIR__ . '/translation-stubs.php';
+}
+
+namespace Tests {
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class BlcDashboardLinksPageTest extends TestCase
+{
+    /**
+     * @var array<string, mixed>
+     */
+    private array $options = [];
+
+    /**
+     * @var object|null
+     */
+    private $previous_wpdb;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        require_once __DIR__ . '/../vendor/autoload.php';
+        Monkey\setUp();
+
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', __DIR__ . '/../');
+        }
+
+        if (!defined('ARRAY_A')) {
+            define('ARRAY_A', 'ARRAY_A');
+        }
+
+        if (!class_exists('WP_List_Table')) {
+            require_once __DIR__ . '/stubs/WP_List_Table.php';
+        }
+
+        $this->options = [
+            'blc_last_check_time' => 0,
+        ];
+
+        $this->previous_wpdb = $GLOBALS['wpdb'] ?? null;
+
+        $GLOBALS['wpdb'] = new class() {
+            /** @var string */
+            public $prefix = 'wp_';
+
+            public function prepare($query, ...$args)
+            {
+                return $query;
+            }
+
+            public function get_var($query)
+            {
+                return 0;
+            }
+
+            public function get_row($query, $output = ARRAY_A)
+            {
+                return ['total' => 0, 'internal_count' => 0, 'external_count' => 0];
+            }
+
+            public function get_results($query, $output = ARRAY_A)
+            {
+                return [];
+            }
+
+            public function esc_like($text)
+            {
+                return $text;
+            }
+        };
+
+        $test_case = $this;
+
+        Functions\when('get_option')->alias(static function ($name, $default = false) use ($test_case) {
+            return $test_case->getStoredOption((string) $name, $default);
+        });
+        Functions\when('home_url')->justReturn('https://example.com');
+        Functions\when('remove_query_arg')->alias(static fn($key, $url = null) => 'admin.php');
+        Functions\when('add_query_arg')->alias(static function ($key, $value = null, $url = null) {
+            $args = is_array($key) ? $key : [$key => $value];
+
+            return 'admin.php?' . http_build_query($args);
+        });
+        Functions\when('wp_clear_scheduled_hook')->justReturn(true);
+        Functions\when('wp_schedule_single_event')->justReturn(true);
+        Functions\when('wp_nonce_field')->alias(static function () {
+            echo '';
+
+            return '';
+        });
+        Functions\when('wp_kses')->alias(static fn($string) => $string);
+        Functions\when('wp_kses_post')->alias(static fn($string) => $string);
+        Functions\when('wp_unslash')->alias(static fn($value) => $value);
+        Functions\when('sanitize_text_field')->alias(static fn($value) => is_scalar($value) ? (string) $value : '');
+        Functions\when('number_format_i18n')->alias(static function ($number, $decimals = 0) {
+            return number_format((float) $number, (int) $decimals);
+        });
+
+        require_once __DIR__ . '/../liens-morts-detector-jlg/includes/blc-admin-pages.php';
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+
+        if ($this->previous_wpdb !== null) {
+            $GLOBALS['wpdb'] = $this->previous_wpdb;
+        }
+
+        $_POST = [];
+    }
+
+    public function test_last_check_time_uses_site_timezone(): void
+    {
+        $timestamp = gmmktime(23, 0, 0, 12, 31, 2023);
+        $this->setStoredOption('blc_last_check_time', $timestamp);
+
+        $timezone = new \DateTimeZone('Pacific/Kiritimati');
+
+        Functions\when('wp_timezone')->alias(static fn() => $timezone);
+        Functions\when('wp_date')->alias(static function ($format, $timestamp = null, $tz = null) use ($timezone) {
+            $timestamp = $timestamp ?? time();
+            $target_tz = $tz ?? $timezone;
+
+            $date = new \DateTime('@' . $timestamp);
+            $date->setTimezone($target_tz);
+
+            return $date->format($format);
+        });
+
+        ob_start();
+        blc_dashboard_links_page();
+        $output = (string) ob_get_clean();
+
+        $this->assertStringContainsString('1 Jan 2024', $output);
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $default
+     *
+     * @return mixed
+     */
+    private function getStoredOption(string $name, $default = false)
+    {
+        return array_key_exists($name, $this->options) ? $this->options[$name] : $default;
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $value
+     */
+    private function setStoredOption(string $name, $value): void
+    {
+        $this->options[$name] = $value;
+    }
+}
+
+}
+


### PR DESCRIPTION
## Summary
- display the broken links dashboard last check date using `wp_date()` so timestamps are converted to the site timezone
- add a PHPUnit scenario that forces a non-UTC timezone and asserts the rendered date matches the expected local day

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d2cfbbeb44832e9ff727cf375cc23b