### PR TITLE
Handle mb_convert_encoding failure in DOM builder

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -293,6 +293,9 @@ function blc_create_dom_from_content($content, $charset = 'UTF-8') {
 
     if (function_exists('mb_convert_encoding')) {
         $content_for_dom = mb_convert_encoding($content, 'HTML-ENTITIES', $charset);
+        if ($content_for_dom === false) {
+            $content_for_dom = $content;
+        }
     } else {
         $content_for_dom = $content;
     }


### PR DESCRIPTION
## Summary
- ensure `blc_create_dom_from_content()` falls back to the original content when `mb_convert_encoding()` fails

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d3be1cd0c4832e8fe34e5f023b60b8