### PR TITLE
Fix manual scan scheduling and charset handling

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -56,8 +56,8 @@ function blc_dashboard_links_page() {
         check_admin_referer('blc_manual_check_nonce');
         $is_full = isset($_POST['blc_full_scan']);
         $bypass_rest_window = $is_full;
-        wp_clear_scheduled_hook('blc_check_batch');
-        wp_schedule_single_event(time(), 'blc_check_batch', array(0, $is_full, $bypass_rest_window));
+        wp_clear_scheduled_hook('blc_manual_check_batch');
+        wp_schedule_single_event(time(), 'blc_manual_check_batch', array(0, $is_full, $bypass_rest_window));
         printf(
             '<div class="notice notice-success is-dismissible"><p>%s</p></div>',
             esc_html__("La vérification des liens a été programmée et s'exécute en arrière-plan.", 'liens-morts-detector-jlg')

--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -819,6 +819,8 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
     }
 
     // --- 5. Sauvegarde et planification ---
+    wp_reset_postdata();
+
     if ($temporary_retry_scheduled) {
         if ($debug_mode) { error_log('Scan reporté : statut HTTP temporaire détecté, nouveau passage planifié.'); }
         return;
@@ -1001,6 +1003,8 @@ function blc_perform_image_check($batch = 0, $is_full_scan = true) { // Une anal
             }
         }
     }
+
+    wp_reset_postdata();
 
     if ($query->max_num_pages > ($batch + 1)) {
         // On utilise un hook de batch différent pour ne pas interférer

--- a/liens-morts-detector-jlg/includes/blc-utils.php
+++ b/liens-morts-detector-jlg/includes/blc-utils.php
@@ -111,6 +111,50 @@ function blc_normalize_post_content_encoding($post_content) {
 
 
 /**
+ * Convert UTF-8 content back to the blog charset for storage in the database.
+ *
+ * @param string $utf8_content Content encoded in UTF-8.
+ *
+ * @return string Content converted to the configured blog charset when possible.
+ */
+function blc_restore_post_content_encoding($utf8_content) {
+    $utf8_content = (string) $utf8_content;
+
+    $target_charset = 'UTF-8';
+    if (function_exists('get_bloginfo')) {
+        $blog_charset = get_bloginfo('charset');
+        if (is_string($blog_charset)) {
+            $blog_charset = trim($blog_charset);
+        }
+
+        if (!empty($blog_charset)) {
+            $target_charset = $blog_charset;
+        }
+    }
+
+    if (strcasecmp($target_charset, 'UTF-8') === 0) {
+        return $utf8_content;
+    }
+
+    if (function_exists('mb_convert_encoding')) {
+        $converted = @mb_convert_encoding($utf8_content, $target_charset, 'UTF-8');
+        if (is_string($converted)) {
+            return $converted;
+        }
+    }
+
+    if (function_exists('iconv')) {
+        $converted = @iconv('UTF-8', $target_charset . '//IGNORE', $utf8_content);
+        if (is_string($converted)) {
+            return $converted;
+        }
+    }
+
+    return $utf8_content;
+}
+
+
+/**
  * Update the href attribute of matching <a> tags without reserializing the whole document.
  *
  * @param string $html            Original HTML content.

--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -58,6 +58,7 @@ add_filter('cron_schedules', 'blc_add_cron_schedules');
 // Lie nos fonctions de scan aux tâches planifiées
 add_action('blc_check_links', 'blc_perform_check');
 add_action('blc_check_batch', 'blc_perform_check', 10, 3);
+add_action('blc_manual_check_batch', 'blc_perform_check', 10, 3);
 add_action('blc_check_image_batch', 'blc_perform_image_check', 10, 2);
 
 // Ajoute nos fichiers CSS et JS dans l'administration
@@ -379,6 +380,7 @@ function blc_ajax_edit_link_callback() {
     }
 
     $new_content = $replacement['content'];
+    $new_content = blc_restore_post_content_encoding($new_content);
     $update_result = wp_update_post([
         'ID' => $post_id,
         'post_content' => wp_slash($new_content),

--- a/tests/BlcAjaxCallbacksTest.php
+++ b/tests/BlcAjaxCallbacksTest.php
@@ -352,8 +352,23 @@ class BlcAjaxCallbacksTest extends TestCase
         $this->assertIsArray($captured_update[0]);
         $this->assertSame(22, $captured_update[0]['ID']);
         $this->assertSame('http://nouveau.com', $_POST['new_url']);
-        $this->assertStringContainsString('href="http://nouveau.com"', $captured_update[0]['post_content']);
-        $this->assertMatchesRegularExpression('/Caf(é|&eacute;)/u', $captured_update[0]['post_content']);
+        $updated_content = $captured_update[0]['post_content'];
+        $this->assertStringContainsString('href="http://nouveau.com"', $updated_content);
+
+        $content_for_assertion = $updated_content;
+        if (function_exists('mb_convert_encoding')) {
+            $converted = @mb_convert_encoding($content_for_assertion, 'UTF-8', 'ISO-8859-1');
+            if (is_string($converted)) {
+                $content_for_assertion = $converted;
+            }
+        } elseif (function_exists('iconv')) {
+            $converted = @iconv('ISO-8859-1', 'UTF-8//IGNORE', $content_for_assertion);
+            if (is_string($converted)) {
+                $content_for_assertion = $converted;
+            }
+        }
+
+        $this->assertMatchesRegularExpression('/Caf(é|&eacute;)/u', $content_for_assertion);
 
         $this->assertIsArray($wpdb->delete_args);
         $this->assertSame('blc_broken_links', $wpdb->delete_args[0]);

--- a/tests/BlcScannerTest.php
+++ b/tests/BlcScannerTest.php
@@ -155,6 +155,7 @@ class BlcScannerTest extends TestCase
             return $records;
         });
         Functions\when('gethostbynamel')->alias(fn(string $hostname) => ['93.184.216.34']);
+        Functions\when('wp_reset_postdata')->justReturn(null);
         Functions\when('wp_kses_bad_protocol')->alias(function ($string, $allowed_protocols = []) {
             $string = (string) $string;
             $allowed_protocols = array_map('strtolower', (array) $allowed_protocols);


### PR DESCRIPTION
## Summary
- add a helper to restore post content to the blog charset before saving edited links
- schedule manual scans on a dedicated cron hook and reset global post data after link/image batches
- update tests to cover the charset conversion and new cron behaviour stubs

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d3da8ed6bc832eb77a8c1cf2639115