### PR TITLE
Sanitize AJAX URLs and harden scheduled task cleanup

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-activation.php
+++ b/liens-morts-detector-jlg/includes/blc-activation.php
@@ -213,8 +213,9 @@ function blc_activation() {
 function blc_deactivation() {
     // Supprime la tâche planifiée principale pour les liens
     wp_clear_scheduled_hook('blc_check_links');
-    
+
     // Supprime également toute tâche de lot qui aurait pu rester en attente
     wp_clear_scheduled_hook('blc_check_batch');
+    wp_clear_scheduled_hook('blc_manual_check_batch');
     wp_clear_scheduled_hook('blc_check_image_batch');
 }

--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -920,6 +920,13 @@ function blc_perform_image_check($batch = 0, $is_full_scan = true) { // Une anal
             if (!$hosts_match_site && !$hosts_match_upload) {
                 continue;
             }
+            if (!$hosts_match_site && $hosts_match_upload) {
+                $is_safe_remote_host = blc_is_safe_remote_host($image_host);
+                if (!$is_safe_remote_host) {
+                    if ($debug_mode) { error_log("  -> Image ignorée (IP non autorisée) : " . $normalized_image_url); }
+                    continue;
+                }
+            }
             if (empty($upload_baseurl) || empty($upload_basedir) || empty($normalized_basedir)) {
                 continue;
             }

--- a/liens-morts-detector-jlg/uninstall.php
+++ b/liens-morts-detector-jlg/uninstall.php
@@ -34,5 +34,6 @@ $wpdb->query("DROP TABLE IF EXISTS $table_name");
 // Nettoyage final des tâches planifiées (par sécurité, même si la désactivation le fait déjà)
 wp_clear_scheduled_hook('blc_check_links');
 wp_clear_scheduled_hook('blc_check_batch');
+wp_clear_scheduled_hook('blc_manual_check_batch');
 wp_clear_scheduled_hook('blc_check_image_batch');
 


### PR DESCRIPTION
## Summary
- sanitize URLs from AJAX callbacks before validation and storage
- reuse the sanitized value throughout link editing and unlinking workflows
- verify CDN hosts during image scans and clear manual cron hooks on deactivation/uninstall

## Testing
- `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68d3e633a59c832eaf2c60315cfc4a5a