### PR TITLE
Add email notifications after link and image scans

### DIFF
--- a/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
+++ b/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
@@ -4,6 +4,7 @@ jQuery(document).ready(function($) {
     var editPromptDefault = messages.editPromptDefault || 'https://';
     var unlinkConfirmation = messages.unlinkConfirmation || "Êtes-vous sûr de vouloir supprimer ce lien ? Le texte sera conservé.";
     var errorPrefix = messages.errorPrefix || 'Erreur : ';
+    var recheckScheduled = messages.recheckScheduled || '';
 
     /**
      * Gère le clic sur le bouton "Modifier le lien".
@@ -75,5 +76,41 @@ jQuery(document).ready(function($) {
                 }
             });
         }
+    });
+
+    $('#the-list').on('click', '.blc-recheck', function(e) {
+        e.preventDefault();
+
+        var linkElement = $(this);
+        if (linkElement.hasClass('is-busy')) {
+            return;
+        }
+
+        var postId = linkElement.data('postid');
+        var urlToRecheck = linkElement.data('url');
+        var nonce = linkElement.data('nonce');
+        var tableRow = linkElement.closest('tr');
+
+        linkElement.addClass('is-busy');
+        tableRow.css('opacity', 0.5);
+
+        $.post(ajaxurl, {
+            action: 'blc_recheck_link',
+            post_id: postId,
+            url_to_recheck: urlToRecheck,
+            _ajax_nonce: nonce
+        }, function(response) {
+            if (response && response.success) {
+                if (recheckScheduled) {
+                    alert(recheckScheduled);
+                }
+            } else {
+                var message = response && response.data && response.data.message ? response.data.message : '';
+                alert(errorPrefix + message);
+            }
+        }).always(function() {
+            linkElement.removeClass('is-busy');
+            tableRow.css('opacity', 1);
+        });
     });
 });

--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -57,7 +57,7 @@ function blc_dashboard_links_page() {
         $is_full = isset($_POST['blc_full_scan']);
         $bypass_rest_window = $is_full;
         wp_clear_scheduled_hook('blc_manual_check_batch');
-        wp_schedule_single_event(time(), 'blc_manual_check_batch', array(0, $is_full, $bypass_rest_window));
+        wp_schedule_single_event(time(), 'blc_manual_check_batch', array(0, $is_full, $bypass_rest_window, array()));
         printf(
             '<div class="notice notice-success is-dismissible"><p>%s</p></div>',
             esc_html__("La vérification des liens a été programmée et s'exécute en arrière-plan.", 'liens-morts-detector-jlg')
@@ -288,6 +288,13 @@ function blc_settings_page() {
         $debug_mode = isset($_POST['blc_debug_mode']);
         update_option('blc_debug_mode', $debug_mode);
 
+        $email_notifications_enabled = isset($_POST['blc_email_notifications_enabled']);
+        update_option('blc_email_notifications_enabled', (bool) $email_notifications_enabled);
+
+        $email_recipients_raw = isset($_POST['blc_email_recipients']) ? wp_unslash($_POST['blc_email_recipients']) : '';
+        $email_recipients = sanitize_textarea_field($email_recipients_raw);
+        update_option('blc_email_recipients', $email_recipients);
+
         wp_clear_scheduled_hook('blc_check_links');
         wp_schedule_event(time(), $frequency, 'blc_check_links');
         if ($frequency_warning !== '') {
@@ -337,6 +344,8 @@ function blc_settings_page() {
     $scan_method = get_option('blc_scan_method', 'precise');
     $excluded_domains = get_option('blc_excluded_domains', "x.com\ntwitter.com\nlinkedin.com");
     $debug_mode = get_option('blc_debug_mode', false);
+    $email_notifications_enabled = (bool) get_option('blc_email_notifications_enabled', false);
+    $email_recipients = get_option('blc_email_recipients', '');
     ?>
     <div class="wrap">
         <h1><?php esc_html_e('Réglages des liens morts', 'liens-morts-detector-jlg'); ?></h1>
@@ -441,6 +450,28 @@ function blc_settings_page() {
                         <td>
                            <textarea name="blc_excluded_domains" id="blc_excluded_domains" rows="5" class="large-text"><?php echo esc_textarea($excluded_domains); ?></textarea>
                            <p class="description"><?php esc_html_e('Domaines à ignorer pendant l\'analyse. Un domaine par ligne (ex: amazon.fr).', 'liens-morts-detector-jlg'); ?></p>
+                        </td>
+                    </tr>
+                 </tbody>
+            </table>
+            <h2><?php esc_html_e('Notifications', 'liens-morts-detector-jlg'); ?></h2>
+            <table class="form-table" role="presentation">
+                 <tbody>
+                    <tr>
+                        <th scope="row"><?php esc_html_e('Alertes par e-mail', 'liens-morts-detector-jlg'); ?></th>
+                        <td>
+                            <label for="blc_email_notifications_enabled">
+                                <input type="checkbox" name="blc_email_notifications_enabled" id="blc_email_notifications_enabled" <?php checked($email_notifications_enabled, true); ?>>
+                                <?php esc_html_e('Envoyer un rapport après chaque analyse terminée.', 'liens-morts-detector-jlg'); ?>
+                            </label>
+                            <p class="description"><?php esc_html_e('Le rapport récapitule le nombre de liens ou d\'images cassés détectés et les éléments les plus récents.', 'liens-morts-detector-jlg'); ?></p>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row"><label for="blc_email_recipients"><?php esc_html_e('Destinataires', 'liens-morts-detector-jlg'); ?></label></th>
+                        <td>
+                            <textarea name="blc_email_recipients" id="blc_email_recipients" rows="4" class="large-text"><?php echo esc_textarea($email_recipients); ?></textarea>
+                            <p class="description"><?php esc_html_e('Une adresse e-mail par ligne. L\'adresse de l\'administrateur du site sera utilisée par défaut si ce champ est vide.', 'liens-morts-detector-jlg'); ?></p>
                         </td>
                     </tr>
                  </tbody>

--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -217,6 +217,13 @@ class BLC_Links_List_Table extends WP_List_Table {
             wp_create_nonce('blc_unlink_nonce'),
             esc_html__('Dissocier', 'liens-morts-detector-jlg')
         );
+        $actions['recheck'] = sprintf(
+            '<a href="#" class="blc-recheck" data-postid="%d" data-url="%s" data-nonce="%s">%s</a>',
+            $item['post_id'],
+            esc_attr($item['url']),
+            wp_create_nonce('blc_recheck_link_nonce'),
+            esc_html__('Re-vérifier', 'liens-morts-detector-jlg')
+        );
         return $actions;
     }
 

--- a/liens-morts-detector-jlg/uninstall.php
+++ b/liens-morts-detector-jlg/uninstall.php
@@ -18,6 +18,8 @@ $options_to_delete = [
     'blc_scan_method',
     'blc_excluded_domains',
     'blc_debug_mode',
+    'blc_email_notifications_enabled',
+    'blc_email_recipients',
     'blc_plugin_db_version'
 ];
 
@@ -34,5 +36,6 @@ $wpdb->query("DROP TABLE IF EXISTS $table_name");
 // Nettoyage final des tâches planifiées (par sécurité, même si la désactivation le fait déjà)
 wp_clear_scheduled_hook('blc_check_links');
 wp_clear_scheduled_hook('blc_check_batch');
+wp_clear_scheduled_hook('blc_manual_check_batch');
 wp_clear_scheduled_hook('blc_check_image_batch');
 


### PR DESCRIPTION
## Summary
- add admin settings to enable scan completion emails and capture recipient list
- send localized scan summary emails for link and image checks using sanitized caches and new filters
- expand the scanner test suite with notification coverage and enhanced wpdb stub behavior

## Testing
- `vendor/bin/phpunit tests` (emits existing mb_convert_encoding deprecation warnings)

------
https://chatgpt.com/codex/tasks/task_e_68d3e633a59c832eaf2c60315cfc4a5a