### PR TITLE
Sécurise la maintenance des liens et le nettoyage multisite

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-activation.php
+++ b/liens-morts-detector-jlg/includes/blc-activation.php
@@ -243,6 +243,15 @@ function blc_activation() {
 
     // On récupère la fréquence de scan enregistrée, ou 'daily' par défaut
     $frequency = get_option('blc_frequency', 'daily');
+    $frequency = is_string($frequency) ? trim($frequency) : '';
+    if ($frequency === '') {
+        $frequency = 'daily';
+    }
+
+    $schedules = wp_get_schedules();
+    if (!isset($schedules[$frequency])) {
+        $frequency = 'daily';
+    }
 
     // On vérifie si une tâche est déjà planifiée pour éviter les doublons
     if (!wp_next_scheduled('blc_check_links')) {

--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -18,6 +18,8 @@ class BLC_Links_List_Table extends WP_List_Table {
 
     private $site_url;
 
+    private $internal_url_condition_cache = null;
+
     /**
      * Constructeur de la classe.
      */
@@ -280,6 +282,10 @@ class BLC_Links_List_Table extends WP_List_Table {
     }
 
     private function build_internal_url_condition() {
+        if (is_array($this->internal_url_condition_cache)) {
+            return $this->internal_url_condition_cache;
+        }
+
         global $wpdb;
 
         $patterns = [];
@@ -359,7 +365,7 @@ class BLC_Links_List_Table extends WP_List_Table {
             $not_params      = array_merge($not_params, $pattern['params']);
         }
 
-        return [
+        $this->internal_url_condition_cache = [
             'sql'           => '(' . implode(' OR ', $or_conditions) . ')',
             'params'        => $case_params,
             'case_template' => 'CASE ' . implode(' ', $case_clauses) . ' ELSE 0 END',
@@ -367,5 +373,7 @@ class BLC_Links_List_Table extends WP_List_Table {
             'not_sql'       => '(' . implode(' AND ', $not_clauses) . ')',
             'not_params'    => $not_params,
         ];
+
+        return $this->internal_url_condition_cache;
     }
 }

--- a/tests/BlcAjaxCallbacksTest.php
+++ b/tests/BlcAjaxCallbacksTest.php
@@ -87,6 +87,9 @@ class BlcAjaxCallbacksTest extends TestCase
         Functions\when('wp_http_validate_url')->alias(function ($url) {
             return filter_var($url, FILTER_VALIDATE_URL) ? $url : false;
         });
+        Functions\when('esc_url_raw')->alias(static function ($url) {
+            return (string) $url;
+        });
         Functions\when('is_wp_error')->alias(function () {
             return false;
         });
@@ -577,7 +580,7 @@ class BlcAjaxCallbacksTest extends TestCase
 
         Functions\when('check_ajax_referer')->justReturn(true);
         Functions\expect('get_post')->once()->with(11)->andReturn(null);
-        Functions\expect('current_user_can')->never();
+        Functions\expect('current_user_can')->once()->with('manage_options')->andReturn(true);
 
         global $wpdb;
         $wpdb = new class {
@@ -870,7 +873,11 @@ class BlcAjaxCallbacksTest extends TestCase
 
         Functions\when('check_ajax_referer')->justReturn(true);
         Functions\expect('get_post')->once()->with(21)->andReturn(null);
-        Functions\expect('current_user_can')->never();
+        Functions\expect('current_user_can')->once()->with('manage_options')->andReturn(true);
+
+        Functions\when('esc_url_raw')->alias(function ($url) {
+            return $url;
+        });
 
         global $wpdb;
         $wpdb = new class {

--- a/tests/BlcScannerTest.php
+++ b/tests/BlcScannerTest.php
@@ -158,6 +158,9 @@ class BlcScannerTest extends TestCase
 
             return $base;
         });
+        Functions\when('esc_url_raw')->alias(static function ($url) {
+            return (string) $url;
+        });
         Functions\when('site_url')->alias(function ($path = '', $scheme = null) {
             $base = 'https://example.com';
             if ($path !== '') {


### PR DESCRIPTION
## Summary
- protège les callbacks AJAX en validant les permissions même quand l’article a disparu, en normalisant les URL et en fiabilisant les identifiants reçus
- vérifie la fréquence enregistrée avant de planifier la tâche cron et met en cache le calcul du filtre SQL des URL internes
- supprime les données du plugin sur l’ensemble du réseau lors de la désinstallation et adapte les tests aux nouvelles sécurités

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d416783924832e976c3f71d52463bf