### PR TITLE
Refactor link handling and add cache invalidation

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -73,14 +73,7 @@ function blc_dashboard_links_page() {
             'link'
         )
     );
-    $option_size_bytes = (int) $wpdb->get_var(
-        $wpdb->prepare(
-            "SELECT SUM(COALESCE(LENGTH(url), 0) + COALESCE(LENGTH(anchor), 0) + COALESCE(LENGTH(post_title), 0))
-             FROM $table_name
-             WHERE type = %s",
-            'link'
-        )
-    );
+    $option_size_bytes = blc_get_dataset_storage_footprint_bytes('link');
     $last_check_time    = get_option('blc_last_check_time', 0);
     $option_size_kb     = $option_size_bytes / 1024;
     $size_display       = ($option_size_kb < 1024)
@@ -167,14 +160,7 @@ function blc_dashboard_images_page() {
             'image'
         )
     );
-    $option_size_bytes = (int) $wpdb->get_var(
-        $wpdb->prepare(
-            "SELECT SUM(COALESCE(LENGTH(url), 0) + COALESCE(LENGTH(anchor), 0) + COALESCE(LENGTH(post_title), 0))
-             FROM $table_name
-             WHERE type = %s",
-            'image'
-        )
-    );
+    $option_size_bytes = blc_get_dataset_storage_footprint_bytes('image');
     $last_image_check_time = get_option('blc_last_image_check_time', 0);
     $option_size_kb      = $option_size_bytes / 1024;
     $size_display        = ($option_size_kb < 1024)

--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -692,6 +692,7 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
 
     $cleanup_sql = "DELETE blc FROM $table_name AS blc LEFT JOIN {$wpdb->posts} AS posts ON blc.post_id = posts.ID WHERE blc.type = %s AND posts.ID IS NULL";
     $wpdb->query($wpdb->prepare($cleanup_sql, 'link'));
+    blc_flush_dataset_size_cache('link');
 
     $post_ids_in_batch = wp_list_pluck($posts, 'ID');
     if (!empty($post_ids_in_batch)) {
@@ -699,6 +700,7 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
         $placeholders = implode(',', array_fill(0, count($post_ids_in_batch), '%d'));
         $delete_sql = "DELETE FROM $table_name WHERE post_id IN ($placeholders) AND type = %s";
         $wpdb->query($wpdb->prepare($delete_sql, array_merge($post_ids_in_batch, ['link'])));
+        blc_flush_dataset_size_cache('link');
     }
 
     // --- 4. Boucle d'analyse des LIENS <a> ---
@@ -817,6 +819,7 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
                             ],
                             ['%s', '%s', '%d', '%s', '%s']
                         );
+                        blc_flush_dataset_size_cache('link');
                         continue;
                     }
                 }
@@ -870,6 +873,7 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
                         ],
                         ['%s', '%s', '%d', '%s', '%s']
                     );
+                    blc_flush_dataset_size_cache('link');
                     $should_skip_remote_request = true;
                 }
             }
@@ -1057,6 +1061,7 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
                     ],
                     ['%s', '%s', '%d', '%s', '%s']
                 );
+                blc_flush_dataset_size_cache('link');
             }
 
             if (!$should_use_cache && $cache_entry_key !== '') {
@@ -1280,6 +1285,7 @@ function blc_perform_image_check($batch = 0, $is_full_scan = true) { // Une anal
                     ],
                     ['%s', '%s', '%d', '%s', '%s']
                 );
+                blc_flush_dataset_size_cache('image');
             }
         }
     }

--- a/tests/BlcAjaxCallbacksTest.php
+++ b/tests/BlcAjaxCallbacksTest.php
@@ -158,7 +158,7 @@ class BlcAjaxCallbacksTest extends TestCase
         Functions\expect('check_ajax_referer')->once()->with('blc_edit_link_nonce')->andReturn(true);
 
         $expected_message = sprintf('Le paramètre requis "%s" est manquant ou vide.', $missing_param);
-        Functions\expect('wp_send_json_error')->once()->with(['message' => $expected_message])->andReturnUsing(function () {
+        Functions\expect('wp_send_json_error')->once()->with(['message' => $expected_message], 400)->andReturnUsing(function () {
             throw new \Exception('error');
         });
 
@@ -206,7 +206,7 @@ class BlcAjaxCallbacksTest extends TestCase
         Functions\expect('check_ajax_referer')->once()->with('blc_unlink_nonce')->andReturn(true);
 
         $expected_message = sprintf('Le paramètre requis "%s" est manquant ou vide.', $missing_param);
-        Functions\expect('wp_send_json_error')->once()->with(['message' => $expected_message])->andReturnUsing(function () {
+        Functions\expect('wp_send_json_error')->once()->with(['message' => $expected_message], 400)->andReturnUsing(function () {
             throw new \Exception('error');
         });
 

--- a/tests/BlcScannerTest.php
+++ b/tests/BlcScannerTest.php
@@ -377,8 +377,8 @@ class BlcScannerTest extends TestCase
             $this->ajaxResponse = ['success' => true, 'data' => $data];
             throw new \RuntimeException('wp_send_json_success');
         });
-        Functions\when('wp_send_json_error')->alias(function ($data = null) {
-            $this->ajaxResponse = ['success' => false, 'data' => $data];
+        Functions\when('wp_send_json_error')->alias(function ($data = null, $status_code = null) {
+            $this->ajaxResponse = ['success' => false, 'data' => $data, 'status' => $status_code];
             throw new \RuntimeException('wp_send_json_error');
         });
 

--- a/tests/RequirePostParamsTest.php
+++ b/tests/RequirePostParamsTest.php
@@ -110,7 +110,7 @@ class RequirePostParamsTest extends TestCase
 
         Functions\expect('wp_send_json_error')
             ->once()
-            ->with(['message' => sprintf('Le paramètre requis "%s" est manquant ou vide.', $missing_param)])
+            ->with(['message' => sprintf('Le paramètre requis "%s" est manquant ou vide.', $missing_param)], 400)
             ->andReturnUsing(static function () {
                 throw new \RuntimeException('wp_send_json_error called');
             });


### PR DESCRIPTION
## Summary
- replace regex-based link updates with DOMDocument helpers and share URL normalization utilities
- send HTTP 400 when required AJAX parameters are missing and restore post encoding before unlink updates
- cache dataset footprint metrics with transient invalidation during scans and quick actions

## Testing
- `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68d42f178f88832ea57cd67faa71dab4