### PR TITLE
Improve throttling and locking for link and image scans

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -177,7 +177,7 @@ function blc_dashboard_images_page() {
         ? sprintf('%s %s', number_format_i18n($option_size_kb, 2), __('Ko', 'liens-morts-detector-jlg'))
         : sprintf('%s %s', number_format_i18n($option_size_kb / 1024, 2), __('Mo', 'liens-morts-detector-jlg'));
     $last_check_display  = $last_image_check_time
-        ? date_i18n('j M Y', $last_image_check_time)
+        ? wp_date('j M Y', $last_image_check_time)
         : __('Jamais', 'liens-morts-detector-jlg');
 
     $list_table = new BLC_Images_List_Table();


### PR DESCRIPTION
## Summary
- replace the per-link sleep with a smarter request throttling window so link scans respect the configured delay without exploding run time
- add a lock, shared batch delay, and local path cache to the image scan pipeline while recording image scan timestamps in UTC for consistent display
- update the admin display and automated tests to reflect the new locking/timestamp behaviour and to persist option stubs during tests

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d44bfaf520832ea1fa677972bdfdef