### PR TITLE
Handle link occurrence indices during link edits

### DIFF
--- a/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
+++ b/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
@@ -15,6 +15,14 @@ jQuery(document).ready(function($) {
         var linkElement = $(this);
         var oldUrl = linkElement.data('url');
         var postId = linkElement.data('postid');
+        var rowId = linkElement.data('rowId');
+        if (typeof rowId === 'undefined') {
+            rowId = '';
+        }
+        var occurrenceIndex = linkElement.data('occurrenceIndex');
+        if (typeof occurrenceIndex === 'undefined') {
+            occurrenceIndex = '';
+        }
         var nonce = linkElement.data('nonce');
 
         // Affiche une boîte de dialogue pour demander la nouvelle URL
@@ -30,6 +38,8 @@ jQuery(document).ready(function($) {
             $.post(ajaxurl, {
                 action: 'blc_edit_link',
                 post_id: postId,
+                row_id: rowId,
+                occurrence_index: occurrenceIndex,
                 old_url: oldUrl,
                 new_url: newUrl,
                 _ajax_nonce: nonce
@@ -55,6 +65,14 @@ jQuery(document).ready(function($) {
         var linkElement = $(this);
         var urlToUnlink = linkElement.data('url');
         var postId = linkElement.data('postid');
+        var rowId = linkElement.data('rowId');
+        if (typeof rowId === 'undefined') {
+            rowId = '';
+        }
+        var occurrenceIndex = linkElement.data('occurrenceIndex');
+        if (typeof occurrenceIndex === 'undefined') {
+            occurrenceIndex = '';
+        }
         var nonce = linkElement.data('nonce');
 
         // Demande une confirmation avant de supprimer le lien
@@ -64,6 +82,8 @@ jQuery(document).ready(function($) {
             $.post(ajaxurl, {
                 action: 'blc_unlink',
                 post_id: postId,
+                row_id: rowId,
+                occurrence_index: occurrenceIndex,
                 url_to_unlink: urlToUnlink,
                 _ajax_nonce: nonce
             }, function(response) {

--- a/liens-morts-detector-jlg/includes/blc-activation.php
+++ b/liens-morts-detector-jlg/includes/blc-activation.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('BLC_DB_VERSION')) {
-    define('BLC_DB_VERSION', '1.5.0');
+    define('BLC_DB_VERSION', '1.6.0');
 }
 
 if (!defined('BLC_TEXT_FIELD_LENGTH')) {
@@ -51,6 +51,10 @@ function blc_maybe_upgrade_database() {
         blc_maybe_add_column($table_name, 'is_internal', 'tinyint(1) NOT NULL DEFAULT 0');
         blc_maybe_add_index($table_name, 'url_host', 'url_host');
         blc_maybe_add_index($table_name, 'is_internal', 'is_internal');
+    }
+
+    if (!$installed_version || version_compare($installed_version, '1.6.0', '<')) {
+        blc_maybe_add_column($table_name, 'occurrence_index', 'int(10) unsigned NOT NULL DEFAULT 0');
     }
 
     update_option('blc_plugin_db_version', BLC_DB_VERSION);
@@ -271,6 +275,7 @@ function blc_activation() {
         post_id bigint(20) unsigned NOT NULL,
         post_title varchar(" . BLC_TEXT_FIELD_LENGTH . ") NULL,
         type varchar(20) NOT NULL,
+        occurrence_index int(10) unsigned NOT NULL DEFAULT 0,
         url_host varchar(191) NULL,
         is_internal tinyint(1) NOT NULL DEFAULT 0,
         PRIMARY KEY  (id),

--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -942,6 +942,8 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
             continue;
         }
 
+        $occurrence_counters = [];
+
         foreach ($dom->getElementsByTagName('a') as $link_node) {
             $original_url = trim(wp_kses_decode_entities($link_node->getAttribute('href')));
             if ($original_url === '') { continue; }
@@ -967,6 +969,13 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
             }
 
             if (empty($parsed_url['scheme']) || !in_array($parsed_url['scheme'], ['http', 'https'], true)) { continue; }
+
+            $counter_key = $url_for_storage;
+            if (!isset($occurrence_counters[$counter_key])) {
+                $occurrence_counters[$counter_key] = 0;
+            }
+            $occurrence_index = $occurrence_counters[$counter_key];
+            $occurrence_counters[$counter_key]++;
 
             if ($upload_basedir && $upload_base_host && isset($parsed_url['host']) && isset($parsed_url['path'])) {
                 if (strcasecmp($upload_base_host, $parsed_url['host']) === 0 && $upload_base_path !== '' && strpos($parsed_url['path'], $upload_base_path) === 0) {
@@ -999,10 +1008,11 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
                                 'post_id'     => $post->ID,
                                 'post_title'  => $post_title_for_storage,
                                 'type'        => 'link',
+                                'occurrence_index' => $occurrence_index,
                                 'url_host'    => $metadata['host'],
                                 'is_internal' => $metadata['is_internal'],
                             ],
-                            ['%s', '%s', '%d', '%s', '%s', '%s', '%d']
+                            ['%s', '%s', '%d', '%s', '%s', '%d', '%s', '%d']
                         );
                         if ($inserted) {
                             blc_adjust_dataset_storage_footprint('link', $row_bytes);
@@ -1057,10 +1067,11 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
                             'post_id'     => $post->ID,
                             'post_title'  => $post_title_for_storage,
                             'type'        => 'link',
+                            'occurrence_index' => $occurrence_index,
                             'url_host'    => $metadata['host'],
                             'is_internal' => $metadata['is_internal'],
                         ],
-                        ['%s', '%s', '%d', '%s', '%s', '%s', '%d']
+                        ['%s', '%s', '%d', '%s', '%s', '%d', '%s', '%d']
                     );
                     if ($inserted) {
                         blc_adjust_dataset_storage_footprint('link', $row_bytes);
@@ -1254,10 +1265,11 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
                         'post_id'     => $post->ID,
                         'post_title'  => $post_title_for_storage,
                         'type'        => 'link',
+                        'occurrence_index' => $occurrence_index,
                         'url_host'    => $metadata['host'],
                         'is_internal' => $metadata['is_internal'],
                     ],
-                    ['%s', '%s', '%d', '%s', '%s', '%s', '%d']
+                    ['%s', '%s', '%d', '%s', '%s', '%d', '%s', '%d']
                 );
                 if ($inserted) {
                     blc_adjust_dataset_storage_footprint('link', $row_bytes);

--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -208,17 +208,25 @@ class BLC_Links_List_Table extends WP_List_Table {
      */
     protected function get_row_actions($item) {
         $actions = [];
-        $actions['edit_link'] = sprintf(
-            '<a href="#" class="blc-edit-link" data-postid="%d" data-url="%s" data-nonce="%s">%s</a>',
+        $row_id = isset($item['id']) ? absint($item['id']) : 0;
+        $occurrence_index = isset($item['occurrence_index']) ? max(0, (int) $item['occurrence_index']) : 0;
+        $data_attributes = sprintf(
+            'data-postid="%d" data-url="%s" data-row-id="%d" data-occurrence-index="%d"',
             $item['post_id'],
             esc_attr($item['url']),
+            $row_id,
+            $occurrence_index
+        );
+
+        $actions['edit_link'] = sprintf(
+            '<a href="#" class="blc-edit-link" %s data-nonce="%s">%s</a>',
+            $data_attributes,
             wp_create_nonce('blc_edit_link_nonce'),
             esc_html__('Modifier', 'liens-morts-detector-jlg')
         );
         $actions['unlink'] = sprintf(
-            '<a href="#" class="blc-unlink" data-postid="%d" data-url="%s" data-nonce="%s" style="color:#a00;">%s</a>',
-            $item['post_id'],
-            esc_attr($item['url']),
+            '<a href="#" class="blc-unlink" %s data-nonce="%s" style="color:#a00;">%s</a>',
+            $data_attributes,
             wp_create_nonce('blc_unlink_nonce'),
             esc_html__('Dissocier', 'liens-morts-detector-jlg')
         );
@@ -272,7 +280,7 @@ class BLC_Links_List_Table extends WP_List_Table {
         $offset = ($current_page - 1) * $per_page;
 
         $data_query = $wpdb->prepare(
-            "SELECT url, anchor, post_id, post_title
+            "SELECT id, occurrence_index, url, anchor, post_id, post_title
              FROM $table_name
              WHERE $where_clause
              ORDER BY id DESC

--- a/tests/RequirePostParamsTest.php
+++ b/tests/RequirePostParamsTest.php
@@ -43,19 +43,23 @@ class RequirePostParamsTest extends TestCase
     public function test_returns_sanitized_values_when_params_are_valid(): void
     {
         $_POST = [
-            'post_id' => '  123 ',
-            'old_url' => ' https://example.com/old  ',
-            'new_url' => "\t\nhttps://example.com/new\t ",
+            'post_id'          => '  123 ',
+            'row_id'           => ' 45 ',
+            'occurrence_index' => ' 2 ',
+            'old_url'          => ' https://example.com/old  ',
+            'new_url'          => "\t\nhttps://example.com/new\t ",
         ];
 
         Functions\expect('wp_send_json_error')->never();
 
-        $result = blc_require_post_params(['post_id', 'old_url', 'new_url']);
+        $result = blc_require_post_params(['post_id', 'row_id', 'occurrence_index', 'old_url', 'new_url']);
 
         $this->assertSame([
-            'post_id' => '123',
-            'old_url' => 'https://example.com/old',
-            'new_url' => 'https://example.com/new',
+            'post_id'          => '123',
+            'row_id'           => '45',
+            'occurrence_index' => '2',
+            'old_url'          => 'https://example.com/old',
+            'new_url'          => 'https://example.com/new',
         ], $result);
     }
 
@@ -63,39 +67,63 @@ class RequirePostParamsTest extends TestCase
     {
         return [
             'missing post_id' => [
-                ['old_url' => 'http://old.com', 'new_url' => 'http://new.com'],
+                ['row_id' => '1', 'occurrence_index' => '0', 'old_url' => 'http://old.com', 'new_url' => 'http://new.com'],
                 'post_id',
             ],
             'null post_id' => [
-                ['post_id' => null, 'old_url' => 'http://old.com', 'new_url' => 'http://new.com'],
+                ['post_id' => null, 'row_id' => '1', 'occurrence_index' => '0', 'old_url' => 'http://old.com', 'new_url' => 'http://new.com'],
                 'post_id',
             ],
             'empty post_id' => [
-                ['post_id' => '   ', 'old_url' => 'http://old.com', 'new_url' => 'http://new.com'],
+                ['post_id' => '   ', 'row_id' => '1', 'occurrence_index' => '0', 'old_url' => 'http://old.com', 'new_url' => 'http://new.com'],
                 'post_id',
             ],
+            'missing row_id' => [
+                ['post_id' => '10', 'occurrence_index' => '0', 'old_url' => 'http://old.com', 'new_url' => 'http://new.com'],
+                'row_id',
+            ],
+            'null row_id' => [
+                ['post_id' => '10', 'row_id' => null, 'occurrence_index' => '0', 'old_url' => 'http://old.com', 'new_url' => 'http://new.com'],
+                'row_id',
+            ],
+            'empty row_id' => [
+                ['post_id' => '10', 'row_id' => '   ', 'occurrence_index' => '0', 'old_url' => 'http://old.com', 'new_url' => 'http://new.com'],
+                'row_id',
+            ],
+            'missing occurrence_index' => [
+                ['post_id' => '10', 'row_id' => '3', 'old_url' => 'http://old.com', 'new_url' => 'http://new.com'],
+                'occurrence_index',
+            ],
+            'null occurrence_index' => [
+                ['post_id' => '10', 'row_id' => '3', 'occurrence_index' => null, 'old_url' => 'http://old.com', 'new_url' => 'http://new.com'],
+                'occurrence_index',
+            ],
+            'empty occurrence_index' => [
+                ['post_id' => '10', 'row_id' => '3', 'occurrence_index' => '   ', 'old_url' => 'http://old.com', 'new_url' => 'http://new.com'],
+                'occurrence_index',
+            ],
             'missing old_url' => [
-                ['post_id' => '10', 'new_url' => 'http://new.com'],
+                ['post_id' => '10', 'row_id' => '3', 'occurrence_index' => '1', 'new_url' => 'http://new.com'],
                 'old_url',
             ],
             'null old_url' => [
-                ['post_id' => '10', 'old_url' => null, 'new_url' => 'http://new.com'],
+                ['post_id' => '10', 'row_id' => '3', 'occurrence_index' => '1', 'old_url' => null, 'new_url' => 'http://new.com'],
                 'old_url',
             ],
             'empty old_url' => [
-                ['post_id' => '10', 'old_url' => '   ', 'new_url' => 'http://new.com'],
+                ['post_id' => '10', 'row_id' => '3', 'occurrence_index' => '1', 'old_url' => '   ', 'new_url' => 'http://new.com'],
                 'old_url',
             ],
             'missing new_url' => [
-                ['post_id' => '10', 'old_url' => 'http://old.com'],
+                ['post_id' => '10', 'row_id' => '3', 'occurrence_index' => '1', 'old_url' => 'http://old.com'],
                 'new_url',
             ],
             'null new_url' => [
-                ['post_id' => '10', 'old_url' => 'http://old.com', 'new_url' => null],
+                ['post_id' => '10', 'row_id' => '3', 'occurrence_index' => '1', 'old_url' => 'http://old.com', 'new_url' => null],
                 'new_url',
             ],
             'empty new_url' => [
-                ['post_id' => '10', 'old_url' => 'http://old.com', 'new_url' => '   '],
+                ['post_id' => '10', 'row_id' => '3', 'occurrence_index' => '1', 'old_url' => 'http://old.com', 'new_url' => '   '],
                 'new_url',
             ],
         ];
@@ -118,6 +146,6 @@ class RequirePostParamsTest extends TestCase
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('wp_send_json_error called');
 
-        blc_require_post_params(['post_id', 'old_url', 'new_url']);
+        blc_require_post_params(['post_id', 'row_id', 'occurrence_index', 'old_url', 'new_url']);
     }
 }


### PR DESCRIPTION
## Summary
- add the `occurrence_index` column to the broken links table and populate it when scanning content
- scope link edit/unlink AJAX handlers to a specific row and occurrence, updating helper utilities and admin UI data attributes accordingly
- refresh JavaScript and PHP unit tests to exercise the new parameters and database access patterns

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d590e8620c832ebd3d3076ac370477