### PR TITLE
Add stale marker workflow for broken link scans

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-activation.php
+++ b/liens-morts-detector-jlg/includes/blc-activation.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('BLC_DB_VERSION')) {
-    define('BLC_DB_VERSION', '1.5.0');
+    define('BLC_DB_VERSION', '1.6.0');
 }
 
 if (!defined('BLC_TEXT_FIELD_LENGTH')) {
@@ -51,6 +51,11 @@ function blc_maybe_upgrade_database() {
         blc_maybe_add_column($table_name, 'is_internal', 'tinyint(1) NOT NULL DEFAULT 0');
         blc_maybe_add_index($table_name, 'url_host', 'url_host');
         blc_maybe_add_index($table_name, 'is_internal', 'is_internal');
+    }
+
+    if (!$installed_version || version_compare($installed_version, '1.6.0', '<')) {
+        blc_maybe_add_column($table_name, 'is_stale', 'tinyint(1) NOT NULL DEFAULT 0');
+        blc_maybe_add_index($table_name, 'is_stale', 'is_stale');
     }
 
     update_option('blc_plugin_db_version', BLC_DB_VERSION);
@@ -273,12 +278,14 @@ function blc_activation() {
         type varchar(20) NOT NULL,
         url_host varchar(191) NULL,
         is_internal tinyint(1) NOT NULL DEFAULT 0,
+        is_stale tinyint(1) NOT NULL DEFAULT 0,
         PRIMARY KEY  (id),
         KEY type (type),
         KEY post_id (post_id),
         KEY url_prefix (url(191)),
         KEY url_host (url_host),
-        KEY is_internal (is_internal)
+        KEY is_internal (is_internal),
+        KEY is_stale (is_stale)
     ) $charset_collate;";
 
     require_once ABSPATH . 'wp-admin/includes/upgrade.php';


### PR DESCRIPTION
## Summary
- add an `is_stale` flag to the broken links table schema and upgrade routine
- mark existing report rows while rescanning links and images, purge them only after successful inserts, and restore markers on failures
- extend the scanner tests with interruption scenarios and support utilities for simulating database errors

## Testing
- `composer install`
- `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68d590e86220832e93ba6f31fc8298fe