### PR TITLE
Add staged refresh workflow for link and image scans

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-activation.php
+++ b/liens-morts-detector-jlg/includes/blc-activation.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('BLC_DB_VERSION')) {
-    define('BLC_DB_VERSION', '1.6.0');
+    define('BLC_DB_VERSION', '1.7.0');
 }
 
 if (!defined('BLC_TEXT_FIELD_LENGTH')) {
@@ -55,6 +55,11 @@ function blc_maybe_upgrade_database() {
 
     if (!$installed_version || version_compare($installed_version, '1.6.0', '<')) {
         blc_maybe_add_column($table_name, 'occurrence_index', 'int(10) unsigned NOT NULL DEFAULT 0');
+    }
+
+    if (!$installed_version || version_compare($installed_version, '1.7.0', '<')) {
+        blc_maybe_add_column($table_name, 'scan_run_id', 'varchar(64) NULL');
+        blc_maybe_add_index($table_name, 'scan_run_id', 'scan_run_id');
     }
 
     update_option('blc_plugin_db_version', BLC_DB_VERSION);


### PR DESCRIPTION
## Summary
- add a `scan_run_id` column so batches can mark existing broken-link rows while they are refreshed
- update the link scanner to stage rows per post, delete them only after successful inserts, and roll back markers on failure
- apply the same staging strategy to the image scanner and add tests covering interrupted batches

## Testing
- vendor/bin/phpunit tests/BlcScannerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d5ad1bf3c4832eb2777e5d3f9065ba