### PR TITLE
Handle unknown occurrence indexes

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-activation.php
+++ b/liens-morts-detector-jlg/includes/blc-activation.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('BLC_DB_VERSION')) {
-    define('BLC_DB_VERSION', '1.7.1');
+    define('BLC_DB_VERSION', '1.7.2');
 }
 
 if (!defined('BLC_TEXT_FIELD_LENGTH')) {
@@ -54,7 +54,8 @@ function blc_maybe_upgrade_database() {
     }
 
     if (!$installed_version || version_compare($installed_version, '1.6.0', '<')) {
-        blc_maybe_add_column($table_name, 'occurrence_index', 'int(10) unsigned NULL DEFAULT NULL');
+        blc_maybe_add_column($table_name, 'occurrence_index', 'int(10) NULL DEFAULT NULL');
+        blc_mark_occurrence_indexes_as_unknown($table_name);
     }
 
     if (!$installed_version || version_compare($installed_version, '1.7.0', '<')) {
@@ -62,7 +63,7 @@ function blc_maybe_upgrade_database() {
         blc_maybe_add_index($table_name, 'scan_run_id', 'scan_run_id');
     }
 
-    if (!$installed_version || version_compare($installed_version, '1.7.1', '<')) {
+    if (!$installed_version || version_compare($installed_version, '1.7.2', '<')) {
         blc_maybe_make_occurrence_index_nullable($table_name);
     }
 
@@ -220,20 +221,32 @@ function blc_maybe_make_occurrence_index_nullable($table_name) {
     $is_nullable   = strtolower((string) ($column_definition->Null ?? '')) === 'yes';
     $default_value = $column_definition->Default;
 
-    $needs_alter = !$is_nullable || $default_value !== null;
+    $is_int_type = strpos($current_type, 'int') !== false;
+    $is_unsigned = strpos($current_type, 'unsigned') !== false;
 
-    if (strpos($current_type, 'int(10) unsigned') === false) {
-        $needs_alter = true;
-    }
+    $needs_alter = !$is_int_type || $is_unsigned || !$is_nullable || $default_value !== null;
 
     if ($needs_alter) {
         $wpdb->query(
-            "ALTER TABLE `$table` MODIFY `occurrence_index` int(10) unsigned NULL DEFAULT NULL"
+            "ALTER TABLE `$table` MODIFY `occurrence_index` int(10) NULL DEFAULT NULL"
         );
     }
 
+    blc_mark_occurrence_indexes_as_unknown($table_name);
+}
+
+/**
+ * Replace placeholder occurrence indexes with a sentinel value that indicates an unknown position.
+ *
+ * @param string $table_name Database table name.
+ */
+function blc_mark_occurrence_indexes_as_unknown($table_name) {
+    global $wpdb;
+
+    $table = esc_sql($table_name);
+
     $wpdb->query(
-        "UPDATE `$table` SET `occurrence_index` = NULL WHERE `occurrence_index` = 0"
+        "UPDATE `$table` SET `occurrence_index` = NULL WHERE `occurrence_index` IS NOT NULL AND `occurrence_index` <= 0"
     );
 }
 
@@ -319,7 +332,7 @@ function blc_activation() {
         post_id bigint(20) unsigned NOT NULL,
         post_title varchar(" . BLC_TEXT_FIELD_LENGTH . ") NULL,
         type varchar(20) NOT NULL,
-        occurrence_index int(10) unsigned NULL DEFAULT NULL,
+        occurrence_index int(10) NULL DEFAULT NULL,
         url_host varchar(191) NULL,
         is_internal tinyint(1) NOT NULL DEFAULT 0,
         PRIMARY KEY  (id),

--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -210,8 +210,12 @@ class BLC_Links_List_Table extends WP_List_Table {
         $actions = [];
         $row_id            = isset($item['id']) ? absint($item['id']) : 0;
         $post_id           = isset($item['post_id']) ? absint($item['post_id']) : 0;
-        $occurrence_raw    = $item['occurrence_index'] ?? null;
-        $has_occurrence    = is_numeric($occurrence_raw) && (int) $occurrence_raw >= 0;
+        $occurrence_raw     = $item['occurrence_index'] ?? null;
+        $occurrence_index   = null;
+        if (is_numeric($occurrence_raw)) {
+            $occurrence_index = (int) $occurrence_raw;
+        }
+        $has_occurrence = ($occurrence_index !== null && $occurrence_index >= 0);
         $data_attributes   = [
             sprintf('data-postid="%d"', $post_id),
             sprintf('data-url="%s"', esc_attr($item['url'])),
@@ -219,7 +223,7 @@ class BLC_Links_List_Table extends WP_List_Table {
         ];
 
         if ($has_occurrence) {
-            $data_attributes[] = sprintf('data-occurrence-index="%d"', (int) $occurrence_raw);
+            $data_attributes[] = sprintf('data-occurrence-index="%d"', $occurrence_index);
         }
 
         $data_attributes = implode(' ', $data_attributes);

--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -230,13 +230,19 @@ function blc_ajax_edit_link_callback() {
     }
 
     $has_occurrence_index = ($occurrence_value !== '');
-    if ($has_occurrence_index && preg_match('/^\d+$/', $occurrence_value) !== 1) {
-        wp_send_json_error([
-            'message' => __('Indice d\'occurrence invalide.', 'liens-morts-detector-jlg'),
-        ], 400);
-    }
+    $occurrence_index = null;
+    if ($has_occurrence_index) {
+        if (preg_match('/^-?\d+$/', $occurrence_value) !== 1) {
+            wp_send_json_error([
+                'message' => __('Indice d\'occurrence invalide.', 'liens-morts-detector-jlg'),
+            ], 400);
+        }
 
-    $occurrence_index = $has_occurrence_index ? (int) $occurrence_value : null;
+        $candidate_index = (int) $occurrence_value;
+        if ($candidate_index >= 0) {
+            $occurrence_index = $candidate_index;
+        }
+    }
 
     global $wpdb;
     $table_name = $wpdb->prefix . 'blc_broken_links';
@@ -263,10 +269,15 @@ function blc_ajax_edit_link_callback() {
     }
 
     $stored_occurrence_raw = $row['occurrence_index'] ?? null;
-    $stored_has_occurrence = is_numeric($stored_occurrence_raw) && (int) $stored_occurrence_raw >= 0;
+    $stored_occurrence_index = null;
+    if (is_numeric($stored_occurrence_raw)) {
+        $stored_candidate = (int) $stored_occurrence_raw;
+        if ($stored_candidate >= 0) {
+            $stored_occurrence_index = $stored_candidate;
+        }
+    }
 
-    if ($stored_has_occurrence) {
-        $stored_occurrence_index = (int) $stored_occurrence_raw;
+    if ($stored_occurrence_index !== null) {
         if ($occurrence_index === null || $stored_occurrence_index !== $occurrence_index) {
             wp_send_json_error([
                 'message' => __('L\'occurrence du lien ne correspond plus. Veuillez relancer une analyse.', 'liens-morts-detector-jlg'),
@@ -275,12 +286,6 @@ function blc_ajax_edit_link_callback() {
 
         $occurrence_index = max(0, $stored_occurrence_index);
     } else {
-        if ($has_occurrence_index) {
-            wp_send_json_error([
-                'message' => __('L\'occurrence du lien ne correspond plus. Veuillez relancer une analyse.', 'liens-morts-detector-jlg'),
-            ], 409);
-        }
-
         $occurrence_index = null;
     }
 
@@ -506,13 +511,19 @@ function blc_ajax_unlink_callback() {
     }
 
     $has_occurrence_index = ($occurrence_value !== '');
-    if ($has_occurrence_index && preg_match('/^\d+$/', $occurrence_value) !== 1) {
-        wp_send_json_error([
-            'message' => __('Indice d\'occurrence invalide.', 'liens-morts-detector-jlg'),
-        ], 400);
-    }
+    $occurrence_index = null;
+    if ($has_occurrence_index) {
+        if (preg_match('/^-?\d+$/', $occurrence_value) !== 1) {
+            wp_send_json_error([
+                'message' => __('Indice d\'occurrence invalide.', 'liens-morts-detector-jlg'),
+            ], 400);
+        }
 
-    $occurrence_index = $has_occurrence_index ? (int) $occurrence_value : null;
+        $candidate_index = (int) $occurrence_value;
+        if ($candidate_index >= 0) {
+            $occurrence_index = $candidate_index;
+        }
+    }
 
     global $wpdb;
     $table_name = $wpdb->prefix . 'blc_broken_links';
@@ -539,10 +550,15 @@ function blc_ajax_unlink_callback() {
     }
 
     $stored_occurrence_raw = $row['occurrence_index'] ?? null;
-    $stored_has_occurrence = is_numeric($stored_occurrence_raw) && (int) $stored_occurrence_raw >= 0;
+    $stored_occurrence_index = null;
+    if (is_numeric($stored_occurrence_raw)) {
+        $stored_candidate = (int) $stored_occurrence_raw;
+        if ($stored_candidate >= 0) {
+            $stored_occurrence_index = $stored_candidate;
+        }
+    }
 
-    if ($stored_has_occurrence) {
-        $stored_occurrence_index = (int) $stored_occurrence_raw;
+    if ($stored_occurrence_index !== null) {
         if ($occurrence_index === null || $stored_occurrence_index !== $occurrence_index) {
             wp_send_json_error([
                 'message' => __('L\'occurrence du lien ne correspond plus. Veuillez relancer une analyse.', 'liens-morts-detector-jlg'),
@@ -551,12 +567,6 @@ function blc_ajax_unlink_callback() {
 
         $occurrence_index = max(0, $stored_occurrence_index);
     } else {
-        if ($has_occurrence_index) {
-            wp_send_json_error([
-                'message' => __('L\'occurrence du lien ne correspond plus. Veuillez relancer une analyse.', 'liens-morts-detector-jlg'),
-            ], 409);
-        }
-
         $occurrence_index = null;
     }
 


### PR DESCRIPTION
## Summary
- allow existing rows to mark unknown occurrence indexes during database upgrades and new installs
- omit the occurrence index data attribute for rows with unknown positions in the admin list table
- relax AJAX handlers to accept missing occurrence indexes and fall back to updating all occurrences when the stored index is unknown

## Testing
- `composer install`
- `./vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68d6513f5b84832eb4e340b7b3514fc4