### PR TITLE
Clear dataset size cache during uninstall

### DIFF
--- a/liens-morts-detector-jlg/uninstall.php
+++ b/liens-morts-detector-jlg/uninstall.php
@@ -18,7 +18,9 @@ $options_to_delete = [
     'blc_scan_method',
     'blc_excluded_domains',
     'blc_debug_mode',
-    'blc_plugin_db_version'
+    'blc_plugin_db_version',
+    'blc_dataset_size_link',
+    'blc_dataset_size_image',
 ];
 
 $cleanup_site = static function () use ($options_to_delete) {

--- a/tests/UninstallTest.php
+++ b/tests/UninstallTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class UninstallTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        require_once __DIR__ . '/../vendor/autoload.php';
+
+        Monkey\setUp();
+
+        if (!defined('WP_UNINSTALL_PLUGIN')) {
+            define('WP_UNINSTALL_PLUGIN', true);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+
+        parent::tearDown();
+    }
+
+    public function test_uninstall_deletes_dataset_size_options(): void
+    {
+        $deleted_options = [];
+        $deleted_site_options = [];
+
+        Functions\when('delete_option')->alias(static function (string $option) use (&$deleted_options): void {
+            $deleted_options[] = $option;
+        });
+
+        Functions\when('delete_site_option')->alias(static function (string $option) use (&$deleted_site_options): void {
+            $deleted_site_options[] = $option;
+        });
+
+        Functions\when('is_multisite')->justReturn(false);
+        Functions\when('wp_clear_scheduled_hook')->justReturn();
+
+        global $wpdb;
+
+        $wpdb = new class {
+            public string $prefix = 'wp_';
+
+            public array $queries = [];
+
+            public function query(string $sql): void
+            {
+                $this->queries[] = $sql;
+            }
+        };
+
+        require __DIR__ . '/../liens-morts-detector-jlg/uninstall.php';
+
+        self::assertContains('blc_dataset_size_link', $deleted_options);
+        self::assertContains('blc_dataset_size_image', $deleted_options);
+        self::assertContains('blc_dataset_size_link', $deleted_site_options);
+        self::assertContains('blc_dataset_size_image', $deleted_site_options);
+    }
+}
+


### PR DESCRIPTION
## Summary
- ensure the uninstall routine removes the dataset size cache options
- add a unit test covering the uninstall cleanup behaviour

## Testing
- `./vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68d65d4d2a5c832eb5096ced1d422219