### PR TITLE
Adjust dataset footprint cache updates and add regression coverage

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-utils.php
+++ b/liens-morts-detector-jlg/includes/blc-utils.php
@@ -564,7 +564,19 @@ function blc_adjust_dataset_storage_footprint($type, $delta) {
         return;
     }
 
-    $current = blc_get_dataset_storage_footprint_bytes($type);
+    if (!function_exists('update_option')) {
+        return;
+    }
+
+    $cached = 0;
+    if (function_exists('get_option')) {
+        $cached = get_option($option_name, 0);
+        if (!is_numeric($cached)) {
+            $cached = 0;
+        }
+    }
+
+    $current = max(0, (int) $cached);
     $new_value = $current + (int) $delta;
     if ($new_value < 0) {
         $new_value = 0;

--- a/tests/BlcAjaxCallbacksTest.php
+++ b/tests/BlcAjaxCallbacksTest.php
@@ -14,6 +14,7 @@ namespace Tests {
 use PHPUnit\Framework\TestCase;
 use Brain\Monkey;
 use Brain\Monkey\Functions;
+use Tests\Stubs\OptionsStore;
 
 class BlcAjaxCallbacksTest extends TestCase
 {
@@ -22,6 +23,9 @@ class BlcAjaxCallbacksTest extends TestCase
         parent::setUp();
         require_once __DIR__ . '/../vendor/autoload.php';
         Monkey\setUp();
+
+        require_once __DIR__ . '/wp-option-stubs.php';
+        OptionsStore::reset();
 
         if (!defined('ABSPATH')) {
             define('ABSPATH', __DIR__ . '/../');
@@ -116,6 +120,7 @@ class BlcAjaxCallbacksTest extends TestCase
     protected function tearDown(): void
     {
         Monkey\tearDown();
+        OptionsStore::reset();
         parent::tearDown();
         $_POST = [];
         global $wpdb;

--- a/tests/BlcDashboardImagesPageTest.php
+++ b/tests/BlcDashboardImagesPageTest.php
@@ -9,6 +9,7 @@ namespace Tests {
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
+use Tests\Stubs\OptionsStore;
 
 class BlcDashboardImagesPageTest extends TestCase
 {
@@ -27,6 +28,9 @@ class BlcDashboardImagesPageTest extends TestCase
         parent::setUp();
         require_once __DIR__ . '/../vendor/autoload.php';
         Monkey\setUp();
+
+        require_once __DIR__ . '/wp-option-stubs.php';
+        OptionsStore::reset();
 
         if (!defined('ABSPATH')) {
             define('ABSPATH', __DIR__ . '/../');
@@ -94,6 +98,7 @@ class BlcDashboardImagesPageTest extends TestCase
     protected function tearDown(): void
     {
         Monkey\tearDown();
+        OptionsStore::reset();
         parent::tearDown();
 
         if ($this->previous_wpdb !== null) {

--- a/tests/BlcDashboardLinksPageTest.php
+++ b/tests/BlcDashboardLinksPageTest.php
@@ -9,6 +9,7 @@ namespace Tests {
 use Brain\Monkey;
 use Brain\Monkey\Functions;
 use PHPUnit\Framework\TestCase;
+use Tests\Stubs\OptionsStore;
 
 class BlcDashboardLinksPageTest extends TestCase
 {
@@ -27,6 +28,9 @@ class BlcDashboardLinksPageTest extends TestCase
         parent::setUp();
         require_once __DIR__ . '/../vendor/autoload.php';
         Monkey\setUp();
+
+        require_once __DIR__ . '/wp-option-stubs.php';
+        OptionsStore::reset();
 
         if (!defined('ABSPATH')) {
             define('ABSPATH', __DIR__ . '/../');
@@ -111,6 +115,7 @@ class BlcDashboardLinksPageTest extends TestCase
     protected function tearDown(): void
     {
         Monkey\tearDown();
+        OptionsStore::reset();
         parent::tearDown();
 
         if ($this->previous_wpdb !== null) {

--- a/tests/BlcDatasetSizeCacheTest.php
+++ b/tests/BlcDatasetSizeCacheTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace {
+    require_once __DIR__ . '/translation-stubs.php';
+
+    if (!function_exists('sanitize_key')) {
+        function sanitize_key($key)
+        {
+            $key = strtolower((string) $key);
+
+            return preg_replace('/[^a-z0-9_\-]/', '', $key);
+        }
+    }
+
+}
+
+namespace Tests {
+
+use Brain\Monkey;
+use PHPUnit\Framework\TestCase;
+use Tests\Stubs\OptionsStore;
+
+class BlcDatasetSizeCacheTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        require_once __DIR__ . '/../vendor/autoload.php';
+        Monkey\setUp();
+
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', __DIR__ . '/../');
+        }
+
+        require_once __DIR__ . '/wp-option-stubs.php';
+        OptionsStore::reset();
+
+        require_once __DIR__ . '/../liens-morts-detector-jlg/includes/blc-utils.php';
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        unset($GLOBALS['wpdb']);
+        OptionsStore::reset();
+        parent::tearDown();
+    }
+
+    public function test_adjust_dataset_storage_footprint_updates_cache_without_query(): void
+    {
+        $type = 'link';
+        $actualBytes = 0;
+
+        $wpdbStub = new class {
+            public string $prefix = 'wp_';
+            public int $getVarCalls = 0;
+
+            public function prepare($query, ...$args)
+            {
+                return $query;
+            }
+
+            public function get_var($query)
+            {
+                $this->getVarCalls++;
+
+                return 0;
+            }
+        };
+
+        $GLOBALS['wpdb'] = $wpdbStub;
+
+        $cacheKey = \blc_get_dataset_size_cache_key($type);
+        $this->assertNotSame('', $cacheKey);
+
+        $actualBytes += 120;
+        \blc_adjust_dataset_storage_footprint($type, 120);
+        $this->assertSame($actualBytes, OptionsStore::$options[$cacheKey] ?? null);
+
+        $actualBytes = max(0, $actualBytes - 50);
+        \blc_adjust_dataset_storage_footprint($type, -50);
+        $this->assertSame($actualBytes, OptionsStore::$options[$cacheKey] ?? null);
+
+        $actualBytes = max(0, $actualBytes - 500);
+        \blc_adjust_dataset_storage_footprint($type, -500);
+        $this->assertSame($actualBytes, OptionsStore::$options[$cacheKey] ?? null);
+
+        $this->assertSame(0, $GLOBALS['wpdb']->getVarCalls);
+    }
+}
+}

--- a/tests/wp-option-stubs.php
+++ b/tests/wp-option-stubs.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Tests\Stubs {
+    final class OptionsStore
+    {
+        /** @var array<string, mixed> */
+        public static array $options = [];
+
+        public static function reset(): void
+        {
+            self::$options = [];
+        }
+    }
+}
+
+namespace {
+    use Tests\Stubs\OptionsStore;
+
+    if (!function_exists('get_option')) {
+        function get_option($name, $default = false)
+        {
+            $name = (string) $name;
+
+            return OptionsStore::$options[$name] ?? $default;
+        }
+    }
+
+    if (!function_exists('update_option')) {
+        function update_option($name, $value, $autoload = null)
+        {
+            $name = (string) $name;
+            OptionsStore::$options[$name] = $value;
+
+            return true;
+        }
+    }
+
+    if (!function_exists('delete_option')) {
+        function delete_option($name)
+        {
+            $name = (string) $name;
+
+            if (isset(OptionsStore::$options[$name])) {
+                unset(OptionsStore::$options[$name]);
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- read cached dataset footprint directly from the stored option before applying deltas and clamp invalid values
- provide shared option stubs for tests and add regression coverage for dataset size cache updates

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d66f91d080832ea35529d6cda04278