### PR TITLE
Fix dataset footprint cache handling

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-utils.php
+++ b/liens-morts-detector-jlg/includes/blc-utils.php
@@ -560,24 +560,16 @@ function blc_get_dataset_storage_footprint_bytes($type) {
  */
 function blc_adjust_dataset_storage_footprint($type, $delta) {
     $option_name = blc_get_dataset_size_cache_key($type);
-    if ($option_name === '') {
+    if ($option_name === '' || !function_exists('get_option') || !function_exists('update_option')) {
         return;
     }
 
-    if (!function_exists('update_option')) {
-        return;
+    $cached = get_option($option_name, 0);
+    if (!is_numeric($cached)) {
+        $cached = 0;
     }
 
-    $cached = 0;
-    if (function_exists('get_option')) {
-        $cached = get_option($option_name, 0);
-        if (!is_numeric($cached)) {
-            $cached = 0;
-        }
-    }
-
-    $current = max(0, (int) $cached);
-    $new_value = $current + (int) $delta;
+    $new_value = (int) $cached + (int) $delta;
     if ($new_value < 0) {
         $new_value = 0;
     }

--- a/tests/BlcDatasetSizeCacheTest.php
+++ b/tests/BlcDatasetSizeCacheTest.php
@@ -87,5 +87,18 @@ class BlcDatasetSizeCacheTest extends TestCase
 
         $this->assertSame(0, $GLOBALS['wpdb']->getVarCalls);
     }
+
+    public function test_adjust_dataset_storage_footprint_ignores_invalid_cache_value(): void
+    {
+        $type = 'image';
+        $cacheKey = \blc_get_dataset_size_cache_key($type);
+        $this->assertNotSame('', $cacheKey);
+
+        OptionsStore::$options[$cacheKey] = 'not-a-number';
+
+        \blc_adjust_dataset_storage_footprint($type, 75);
+
+        $this->assertSame(75, OptionsStore::$options[$cacheKey] ?? null);
+    }
 }
 }


### PR DESCRIPTION
## Summary
- read dataset footprint cache via `get_option` and clamp updates before persisting
- extend dataset cache tests to cover invalid cache values and confirm option updates without DB queries

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d675bb9f50832ea7aa9535e2817bbd