### PR TITLE
Normalize scheme-relative URLs before escaping

### DIFF
--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -444,6 +444,9 @@ function blc_ajax_edit_link_callback() {
     }
 
     $old_url = $prepared_old_url;
+    if (strpos($final_new_url, '//') === 0) {
+        $final_new_url = set_url_scheme($final_new_url, $site_scheme);
+    }
     $new_url = esc_url_raw($final_new_url);
     if ($new_url === '') {
         wp_send_json_error(['message' => __('URL invalide.', 'liens-morts-detector-jlg')], BLC_HTTP_BAD_REQUEST);


### PR DESCRIPTION
## Summary
- normalize scheme-relative replacements in `blc_ajax_edit_link_callback` using the detected site scheme before escaping
- add a regression test ensuring `//cdn.example.com/asset.js` inputs are saved with an HTTPS URL

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d69b1029f8832ea67274c9e426e28a