### PR TITLE
Normalize scheme-relative URLs before escaping

### DIFF
--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -445,7 +445,8 @@ function blc_ajax_edit_link_callback() {
 
     $old_url = $prepared_old_url;
     if (strpos($final_new_url, '//') === 0) {
-        $final_new_url = set_url_scheme($final_new_url, $site_scheme);
+        $scheme_for_scheme_relative = (is_string($site_scheme) && $site_scheme !== '') ? $site_scheme : 'http';
+        $final_new_url = set_url_scheme($final_new_url, $scheme_for_scheme_relative);
     }
     $new_url = esc_url_raw($final_new_url);
     if ($new_url === '') {


### PR DESCRIPTION
## Summary
- normalize scheme-relative replacement URLs with the detected site scheme before escaping
- add a regression test ensuring scheme-relative inputs keep the HTTPS scheme after escaping

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d69f262a88832e81431c426a2b2bcb