### PR TITLE
Limit scanners to public post types

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -1002,7 +1002,24 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
     $last_check_time = (int) get_option('blc_last_check_time', 0);
     $table_name      = $wpdb->prefix . 'blc_broken_links';
 
-    $args = ['post_type' => 'any', 'post_status' => 'publish', 'posts_per_page' => $batch_size, 'paged' => $batch + 1];
+    $public_post_types = get_post_types(['public' => true], 'names');
+    if (!is_array($public_post_types)) {
+        $public_post_types = [];
+    }
+    $public_post_types = array_values(array_filter(array_map('strval', $public_post_types), static function ($post_type) {
+        return $post_type !== '';
+    }));
+    if ($public_post_types === []) {
+        $public_post_types = ['post'];
+    }
+
+    // Limiter la requête aux types de contenus publics tout en conservant la pagination et prévoir un repli sur « post ».
+    $args = [
+        'post_type'      => $public_post_types,
+        'post_status'    => 'publish',
+        'posts_per_page' => $batch_size,
+        'paged'          => $batch + 1,
+    ];
     if (!$is_full_scan && $last_check_time > 0) {
         $threshold = gmdate('Y-m-d H:i:s', $last_check_time);
         $args['date_query'] = [[
@@ -1644,7 +1661,24 @@ function blc_perform_image_check($batch = 0, $is_full_scan = true) { // Une anal
     }
 
     $batch_size = 20;
-    $args = ['post_type' => 'any', 'post_status' => 'publish', 'posts_per_page' => $batch_size, 'paged' => $batch + 1];
+    $public_post_types = get_post_types(['public' => true], 'names');
+    if (!is_array($public_post_types)) {
+        $public_post_types = [];
+    }
+    $public_post_types = array_values(array_filter(array_map('strval', $public_post_types), static function ($post_type) {
+        return $post_type !== '';
+    }));
+    if ($public_post_types === []) {
+        $public_post_types = ['post'];
+    }
+
+    // Limiter la requête aux types de contenus publics tout en conservant la pagination et prévoir un repli sur « post ».
+    $args = [
+        'post_type'      => $public_post_types,
+        'post_status'    => 'publish',
+        'posts_per_page' => $batch_size,
+        'paged'          => $batch + 1,
+    ];
     $query = new WP_Query($args);
     $posts = $query->posts;
     $checked_local_paths = [];

--- a/tests/BlcScannerTest.php
+++ b/tests/BlcScannerTest.php
@@ -127,6 +127,9 @@ class BlcScannerTest extends TestCase
     /** @var array{success: bool, data: mixed}|null */
     private ?array $ajaxResponse = null;
 
+    /** @var array<int, string> */
+    private array $publicPostTypes = [];
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -162,6 +165,7 @@ class BlcScannerTest extends TestCase
         $this->utcNow = 1000;
         $GLOBALS['wp_query_queue'] = [];
         $GLOBALS['wp_query_last_args'] = [];
+        $this->publicPostTypes = ['post', 'page'];
 
         Functions\when('get_option')->alias(fn(string $name, $default = false) => $this->options[$name] ?? $default);
         Functions\when('get_transient')->alias(fn(string $key) => $this->transients[$key] ?? false);
@@ -272,6 +276,9 @@ class BlcScannerTest extends TestCase
         });
         Functions\when('trailingslashit')->alias(function ($value) {
             return rtrim((string) $value, "\\/\t\n\r\f ") . '/';
+        });
+        Functions\when('get_post_types')->alias(function ($args = [], $output = 'names', $operator = 'and') {
+            return $this->publicPostTypes;
         });
         Functions\when('get_permalink')->alias(function ($post = null) {
             if (is_object($post) && isset($post->ID)) {
@@ -1340,6 +1347,52 @@ class BlcScannerTest extends TestCase
         );
     }
 
+    public function test_blc_perform_check_limits_queries_to_public_post_types(): void
+    {
+        global $wpdb;
+        $wpdb = $this->createWpdbStub();
+
+        $this->publicPostTypes = ['portfolio', 'case-study'];
+
+        $GLOBALS['wp_query_queue'][] = [
+            'posts' => [],
+            'max_num_pages' => 1,
+        ];
+
+        blc_perform_check(0, true);
+
+        $this->assertNotEmpty($GLOBALS['wp_query_last_args'], 'WP_Query should run during scans.');
+        $args = end($GLOBALS['wp_query_last_args']);
+        $this->assertSame(
+            $this->publicPostTypes,
+            $args['post_type'] ?? null,
+            'Link scans must restrict queries to the list of public post types.'
+        );
+    }
+
+    public function test_blc_perform_check_falls_back_to_post_type_when_public_list_is_empty(): void
+    {
+        global $wpdb;
+        $wpdb = $this->createWpdbStub();
+
+        $this->publicPostTypes = [];
+
+        $GLOBALS['wp_query_queue'][] = [
+            'posts' => [],
+            'max_num_pages' => 1,
+        ];
+
+        blc_perform_check(0, true);
+
+        $this->assertNotEmpty($GLOBALS['wp_query_last_args'], 'WP_Query should run even when no public post types are available.');
+        $args = end($GLOBALS['wp_query_last_args']);
+        $this->assertSame(
+            ['post'],
+            $args['post_type'] ?? null,
+            'Link scans should default to the "post" type when the public list is empty.'
+        );
+    }
+
     public function test_blc_perform_check_skips_excluded_domains_case_insensitively(): void
     {
         global $wpdb;
@@ -2168,6 +2221,29 @@ class BlcScannerTest extends TestCase
         if ($cacheKey !== '') {
             $this->assertSame(0, $this->options[$cacheKey] ?? null, 'Dataset footprint should be restored after rollback.');
         }
+    }
+
+    public function test_blc_perform_image_check_limits_queries_to_public_post_types(): void
+    {
+        global $wpdb;
+        $wpdb = $this->createWpdbStub();
+
+        $this->publicPostTypes = ['portfolio', 'case-study'];
+
+        $GLOBALS['wp_query_queue'][] = [
+            'posts' => [],
+            'max_num_pages' => 1,
+        ];
+
+        blc_perform_image_check(0, true);
+
+        $this->assertNotEmpty($GLOBALS['wp_query_last_args'], 'WP_Query should be executed during image scans.');
+        $args = end($GLOBALS['wp_query_last_args']);
+        $this->assertSame(
+            $this->publicPostTypes,
+            $args['post_type'] ?? null,
+            'Image scans must restrict queries to the list of public post types.'
+        );
     }
 
     public function test_blc_perform_image_check_restores_markers_when_interrupted(): void


### PR DESCRIPTION
## Summary
- update both link and image scans to query public post types returned by `get_post_types`, preserving pagination and providing a documented fallback to `post`
- stub `get_post_types` in the test suite and add coverage for the new filtering behaviour across link and image scans

## Testing
- vendor/bin/phpunit tests/BlcScannerTest.php


------
https://chatgpt.com/codex/tasks/task_e_68d6b34e68c4832eb31850e743a7e236