### PR TITLE
Add configurable HTTP request timeouts

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -246,6 +246,10 @@ function blc_dashboard_images_page() {
  * Affiche la page des réglages du plugin.
  */
 function blc_settings_page() {
+    $timeout_constraints = blc_get_request_timeout_constraints();
+    $head_timeout_limits = $timeout_constraints['head'];
+    $get_timeout_limits  = $timeout_constraints['get'];
+
     if (isset($_POST['blc_save_settings'])) {
         check_admin_referer('blc_settings_nonce');
 
@@ -299,18 +303,38 @@ function blc_settings_page() {
         $batch_delay = max(0, intval($batch_delay_raw));
         update_option('blc_batch_delay', $batch_delay);
 
-        $previous_head_timeout = get_option('blc_head_request_timeout', 5);
+        $previous_head_timeout = blc_normalize_timeout_option(
+            get_option('blc_head_request_timeout', $head_timeout_limits['default']),
+            $head_timeout_limits['default'],
+            $head_timeout_limits['min'],
+            $head_timeout_limits['max']
+        );
         $head_timeout_raw = isset($_POST['blc_head_request_timeout'])
             ? wp_unslash($_POST['blc_head_request_timeout'])
             : $previous_head_timeout;
-        $head_timeout = blc_normalize_timeout_option($head_timeout_raw, $previous_head_timeout, 1.0, 30.0);
+        $head_timeout = blc_normalize_timeout_option(
+            $head_timeout_raw,
+            $previous_head_timeout,
+            $head_timeout_limits['min'],
+            $head_timeout_limits['max']
+        );
         update_option('blc_head_request_timeout', $head_timeout);
 
-        $previous_get_timeout = get_option('blc_get_request_timeout', 10);
+        $previous_get_timeout = blc_normalize_timeout_option(
+            get_option('blc_get_request_timeout', $get_timeout_limits['default']),
+            $get_timeout_limits['default'],
+            $get_timeout_limits['min'],
+            $get_timeout_limits['max']
+        );
         $get_timeout_raw = isset($_POST['blc_get_request_timeout'])
             ? wp_unslash($_POST['blc_get_request_timeout'])
             : $previous_get_timeout;
-        $get_timeout = blc_normalize_timeout_option($get_timeout_raw, $previous_get_timeout, 1.0, 60.0);
+        $get_timeout = blc_normalize_timeout_option(
+            $get_timeout_raw,
+            $previous_get_timeout,
+            $get_timeout_limits['min'],
+            $get_timeout_limits['max']
+        );
         update_option('blc_get_request_timeout', $get_timeout);
 
         $scan_method_raw = isset($_POST['blc_scan_method']) ? wp_unslash($_POST['blc_scan_method']) : '';
@@ -370,17 +394,18 @@ function blc_settings_page() {
     $rest_end_hour = blc_prepare_time_input_value($rest_end_hour_option, '20');
     $link_delay = max(0, (int) get_option('blc_link_delay', 200));
     $batch_delay = max(0, (int) get_option('blc_batch_delay', 60));
+
     $head_request_timeout = blc_normalize_timeout_option(
-        get_option('blc_head_request_timeout', 5),
-        5,
-        1.0,
-        30.0
+        get_option('blc_head_request_timeout', $head_timeout_limits['default']),
+        $head_timeout_limits['default'],
+        $head_timeout_limits['min'],
+        $head_timeout_limits['max']
     );
     $get_request_timeout = blc_normalize_timeout_option(
-        get_option('blc_get_request_timeout', 10),
-        10,
-        1.0,
-        60.0
+        get_option('blc_get_request_timeout', $get_timeout_limits['default']),
+        $get_timeout_limits['default'],
+        $get_timeout_limits['min'],
+        $get_timeout_limits['max']
     );
     $scan_method = get_option('blc_scan_method', 'precise');
     $excluded_domains = get_option('blc_excluded_domains', "x.com\ntwitter.com\nlinkedin.com");
@@ -465,14 +490,14 @@ function blc_settings_page() {
                     <tr>
                         <th scope="row"><label for="blc_head_request_timeout"><?php esc_html_e('⏱️ Timeout requêtes HEAD', 'liens-morts-detector-jlg'); ?></label></th>
                         <td>
-                           <input type="number" name="blc_head_request_timeout" id="blc_head_request_timeout" value="<?php echo esc_attr($head_request_timeout); ?>" min="1" max="30" step="0.5"> <?php esc_html_e('secondes', 'liens-morts-detector-jlg'); ?>
+                           <input type="number" name="blc_head_request_timeout" id="blc_head_request_timeout" value="<?php echo esc_attr($head_request_timeout); ?>" min="<?php echo esc_attr($head_timeout_limits['min']); ?>" max="<?php echo esc_attr($head_timeout_limits['max']); ?>" step="0.5"> <?php esc_html_e('secondes', 'liens-morts-detector-jlg'); ?>
                            <p class="description"><?php esc_html_e('Durée maximale accordée à chaque requête HEAD. (Défaut : 5)', 'liens-morts-detector-jlg'); ?></p>
                         </td>
                     </tr>
                     <tr>
                         <th scope="row"><label for="blc_get_request_timeout"><?php esc_html_e('⏱️ Timeout requêtes GET', 'liens-morts-detector-jlg'); ?></label></th>
                         <td>
-                           <input type="number" name="blc_get_request_timeout" id="blc_get_request_timeout" value="<?php echo esc_attr($get_request_timeout); ?>" min="1" max="60" step="0.5"> <?php esc_html_e('secondes', 'liens-morts-detector-jlg'); ?>
+                           <input type="number" name="blc_get_request_timeout" id="blc_get_request_timeout" value="<?php echo esc_attr($get_request_timeout); ?>" min="<?php echo esc_attr($get_timeout_limits['min']); ?>" max="<?php echo esc_attr($get_timeout_limits['max']); ?>" step="0.5"> <?php esc_html_e('secondes', 'liens-morts-detector-jlg'); ?>
                            <p class="description"><?php esc_html_e('Durée maximale accordée à chaque requête GET lors du fallback. (Défaut : 10)', 'liens-morts-detector-jlg'); ?></p>
                         </td>
                     </tr>

--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -785,17 +785,22 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
     $rest_end_hour   = (int) blc_normalize_hour_option($rest_end_hour_option, '20');
     $link_delay_ms   = max(0, (int) get_option('blc_link_delay', 200));
     $batch_delay_s   = max(0, (int) get_option('blc_batch_delay', 60));
+
+    $timeout_constraints = blc_get_request_timeout_constraints();
+    $head_timeout_limits = $timeout_constraints['head'];
+    $get_timeout_limits  = $timeout_constraints['get'];
+
     $head_request_timeout = blc_normalize_timeout_option(
-        get_option('blc_head_request_timeout', 5),
-        5,
-        1.0,
-        30.0
+        get_option('blc_head_request_timeout', $head_timeout_limits['default']),
+        $head_timeout_limits['default'],
+        $head_timeout_limits['min'],
+        $head_timeout_limits['max']
     );
     $get_request_timeout = blc_normalize_timeout_option(
-        get_option('blc_get_request_timeout', 10),
-        10,
-        1.0,
-        60.0
+        get_option('blc_get_request_timeout', $get_timeout_limits['default']),
+        $get_timeout_limits['default'],
+        $get_timeout_limits['min'],
+        $get_timeout_limits['max']
     );
     $scan_method     = get_option('blc_scan_method', 'precise');
     $excluded_domains_raw = get_option('blc_excluded_domains', '');


### PR DESCRIPTION
## Summary
- centralize the timeout defaults and bounds for HEAD and GET requests
- reuse the shared constraints when saving and displaying the settings so the UI enforces the same limits
- apply the configured timeouts in the scanner and cover both custom and bounded cases with unit tests

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d6b6191484832e9fab3be4ee2e6693