### PR TITLE
Add configurable remote request timeouts

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -299,19 +299,48 @@ function blc_settings_page() {
         $batch_delay = max(0, intval($batch_delay_raw));
         update_option('blc_batch_delay', $batch_delay);
 
-        $previous_head_timeout = get_option('blc_head_request_timeout', 5);
-        $head_timeout_raw = isset($_POST['blc_head_request_timeout'])
-            ? wp_unslash($_POST['blc_head_request_timeout'])
-            : $previous_head_timeout;
-        $head_timeout = blc_normalize_timeout_option($head_timeout_raw, $previous_head_timeout, 1.0, 30.0);
-        update_option('blc_head_request_timeout', $head_timeout);
+        $stored_timeouts = get_option('blc_remote_request_timeouts', []);
+        if (!is_array($stored_timeouts)) {
+            $stored_timeouts = [];
+        }
 
-        $previous_get_timeout = get_option('blc_get_request_timeout', 10);
-        $get_timeout_raw = isset($_POST['blc_get_request_timeout'])
-            ? wp_unslash($_POST['blc_get_request_timeout'])
-            : $previous_get_timeout;
-        $get_timeout = blc_normalize_timeout_option($get_timeout_raw, $previous_get_timeout, 1.0, 60.0);
+        $previous_head_timeout = blc_normalize_timeout_option(
+            $stored_timeouts['head'] ?? get_option('blc_head_request_timeout', 5),
+            5,
+            1.0,
+            30.0
+        );
+
+        $previous_get_timeout = blc_normalize_timeout_option(
+            $stored_timeouts['get'] ?? get_option('blc_get_request_timeout', 10),
+            10,
+            1.0,
+            60.0
+        );
+
+        $timeouts_raw = isset($_POST['blc_remote_request_timeouts'])
+            ? wp_unslash($_POST['blc_remote_request_timeouts'])
+            : [];
+
+        if (!is_array($timeouts_raw)) {
+            $timeouts_raw = [];
+        }
+
+        $head_timeout_candidate = $timeouts_raw['head'] ?? $previous_head_timeout;
+        $get_timeout_candidate  = $timeouts_raw['get'] ?? $previous_get_timeout;
+
+        $head_timeout = blc_normalize_timeout_option($head_timeout_candidate, $previous_head_timeout, 1.0, 30.0);
+        $get_timeout  = blc_normalize_timeout_option($get_timeout_candidate, $previous_get_timeout, 1.0, 60.0);
+
+        update_option('blc_head_request_timeout', $head_timeout);
         update_option('blc_get_request_timeout', $get_timeout);
+        update_option(
+            'blc_remote_request_timeouts',
+            [
+                'head' => $head_timeout,
+                'get'  => $get_timeout,
+            ]
+        );
 
         $scan_method_raw = isset($_POST['blc_scan_method']) ? wp_unslash($_POST['blc_scan_method']) : '';
         $scan_method = sanitize_text_field($scan_method_raw);
@@ -370,14 +399,19 @@ function blc_settings_page() {
     $rest_end_hour = blc_prepare_time_input_value($rest_end_hour_option, '20');
     $link_delay = max(0, (int) get_option('blc_link_delay', 200));
     $batch_delay = max(0, (int) get_option('blc_batch_delay', 60));
+    $stored_timeouts = get_option('blc_remote_request_timeouts', []);
+    if (!is_array($stored_timeouts)) {
+        $stored_timeouts = [];
+    }
+
     $head_request_timeout = blc_normalize_timeout_option(
-        get_option('blc_head_request_timeout', 5),
+        $stored_timeouts['head'] ?? get_option('blc_head_request_timeout', 5),
         5,
         1.0,
         30.0
     );
     $get_request_timeout = blc_normalize_timeout_option(
-        get_option('blc_get_request_timeout', 10),
+        $stored_timeouts['get'] ?? get_option('blc_get_request_timeout', 10),
         10,
         1.0,
         60.0
@@ -465,14 +499,14 @@ function blc_settings_page() {
                     <tr>
                         <th scope="row"><label for="blc_head_request_timeout"><?php esc_html_e('⏱️ Timeout requêtes HEAD', 'liens-morts-detector-jlg'); ?></label></th>
                         <td>
-                           <input type="number" name="blc_head_request_timeout" id="blc_head_request_timeout" value="<?php echo esc_attr($head_request_timeout); ?>" min="1" max="30" step="0.5"> <?php esc_html_e('secondes', 'liens-morts-detector-jlg'); ?>
+                           <input type="number" name="blc_remote_request_timeouts[head]" id="blc_head_request_timeout" value="<?php echo esc_attr($head_request_timeout); ?>" min="1" max="30" step="0.5"> <?php esc_html_e('secondes', 'liens-morts-detector-jlg'); ?>
                            <p class="description"><?php esc_html_e('Durée maximale accordée à chaque requête HEAD. (Défaut : 5)', 'liens-morts-detector-jlg'); ?></p>
                         </td>
                     </tr>
                     <tr>
                         <th scope="row"><label for="blc_get_request_timeout"><?php esc_html_e('⏱️ Timeout requêtes GET', 'liens-morts-detector-jlg'); ?></label></th>
                         <td>
-                           <input type="number" name="blc_get_request_timeout" id="blc_get_request_timeout" value="<?php echo esc_attr($get_request_timeout); ?>" min="1" max="60" step="0.5"> <?php esc_html_e('secondes', 'liens-morts-detector-jlg'); ?>
+                           <input type="number" name="blc_remote_request_timeouts[get]" id="blc_get_request_timeout" value="<?php echo esc_attr($get_request_timeout); ?>" min="1" max="60" step="0.5"> <?php esc_html_e('secondes', 'liens-morts-detector-jlg'); ?>
                            <p class="description"><?php esc_html_e('Durée maximale accordée à chaque requête GET lors du fallback. (Défaut : 10)', 'liens-morts-detector-jlg'); ?></p>
                         </td>
                     </tr>

--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -785,14 +785,19 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
     $rest_end_hour   = (int) blc_normalize_hour_option($rest_end_hour_option, '20');
     $link_delay_ms   = max(0, (int) get_option('blc_link_delay', 200));
     $batch_delay_s   = max(0, (int) get_option('blc_batch_delay', 60));
+    $remote_request_timeouts = get_option('blc_remote_request_timeouts', []);
+    if (!is_array($remote_request_timeouts)) {
+        $remote_request_timeouts = [];
+    }
+
     $head_request_timeout = blc_normalize_timeout_option(
-        get_option('blc_head_request_timeout', 5),
+        $remote_request_timeouts['head'] ?? get_option('blc_head_request_timeout', 5),
         5,
         1.0,
         30.0
     );
     $get_request_timeout = blc_normalize_timeout_option(
-        get_option('blc_get_request_timeout', 10),
+        $remote_request_timeouts['get'] ?? get_option('blc_get_request_timeout', 10),
         10,
         1.0,
         60.0

--- a/tests/BlcScannerTest.php
+++ b/tests/BlcScannerTest.php
@@ -148,6 +148,10 @@ class BlcScannerTest extends TestCase
             'blc_batch_delay'      => 60,
             'blc_head_request_timeout' => 5,
             'blc_get_request_timeout'  => 10,
+            'blc_remote_request_timeouts' => [
+                'head' => 5,
+                'get'  => 10,
+            ],
             'blc_scan_method'      => 'precise',
             'blc_excluded_domains' => '',
             'blc_last_check_time'  => 0,
@@ -1200,8 +1204,10 @@ class BlcScannerTest extends TestCase
         global $wpdb;
         $wpdb = $this->createWpdbStub();
 
-        $this->options['blc_head_request_timeout'] = '7.5';
-        $this->options['blc_get_request_timeout'] = '120';
+        $this->options['blc_remote_request_timeouts'] = [
+            'head' => '7.5',
+            'get'  => '120',
+        ];
 
         $post = (object) [
             'ID' => 321,


### PR DESCRIPTION
## Summary
- store HEAD and GET request timeouts in the new blc_remote_request_timeouts option and expose the corresponding inputs on the settings page
- read the aggregated timeout option during scans so remote request arguments use the configured values with sane bounds
- adjust scanner tests to rely on the new option when asserting injected timeout values

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d6b5e001e0832ebce8f1f1261fa055