### PR TITLE
Normalize stored URL hosts before saving broken link metadata

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-utils.php
+++ b/liens-morts-detector-jlg/includes/blc-utils.php
@@ -645,8 +645,14 @@ function blc_get_url_metadata_for_storage($original_url, $normalized_url, $site_
         }
     }
 
+    $host_for_storage = '';
+    if ($host !== '') {
+        $max_host_length = defined('BLC_URL_HOST_LENGTH') ? (int) BLC_URL_HOST_LENGTH : 191;
+        $host_for_storage = blc_truncate_for_storage($host, $max_host_length, false);
+    }
+
     return [
-        'host'        => $host,
+        'host'        => $host_for_storage,
         'is_internal' => $is_internal,
     ];
 }


### PR DESCRIPTION
## Summary
- truncate URL host metadata to the configured storage length before saving
- add scanner unit tests that verify long-domain links and images are stored with truncated hosts

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d723f8e578832e84c88c53b4d3c030