### PR TITLE
Handle image scan scheduling failures

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -2015,6 +2015,17 @@ function blc_perform_image_check($batch = 0, $is_full_scan = true) { // Une anal
         if (false === $scheduled) {
             error_log(sprintf('BLC: Failed to schedule next image batch #%d.', $batch + 1));
             do_action('blc_check_image_batch_schedule_failed', $batch + 1, true, 'next_batch');
+
+            if ($lock_token !== '') {
+                blc_release_image_scan_lock($lock_token);
+            }
+
+            delete_option('blc_image_scan_lock_token');
+
+            return new WP_Error(
+                'blc_image_schedule_failed',
+                sprintf('Failed to schedule next image batch #%d.', $batch + 1)
+            );
         }
     } else {
         if ($debug_mode) { error_log("--- Scan IMAGES terminé ---"); }


### PR DESCRIPTION
## Summary
- release the image scan lock and clear the helper token when scheduling the next batch fails
- surface image batch scheduling issues as WP_Error instances for observability
- cover the failure path with a unit test that simulates a cron scheduling failure

## Testing
- ./vendor/bin/phpunit tests/BlcScannerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d7cfed5920832ea6ee8eeac1dd8841