### PR TITLE
Handle image scan scheduling failure

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -2015,6 +2015,20 @@ function blc_perform_image_check($batch = 0, $is_full_scan = true) { // Une anal
         if (false === $scheduled) {
             error_log(sprintf('BLC: Failed to schedule next image batch #%d.', $batch + 1));
             do_action('blc_check_image_batch_schedule_failed', $batch + 1, true, 'next_batch');
+
+            if ($lock_token !== '') {
+                blc_release_image_scan_lock($lock_token);
+            } else {
+                delete_option('blc_image_scan_lock_token');
+            }
+
+            return new \WP_Error(
+                'blc_image_batch_schedule_failed',
+                sprintf(
+                    __('Unable to schedule next image batch #%d.', 'liens-morts-detector-jlg'),
+                    $batch + 1
+                )
+            );
         }
     } else {
         if ($debug_mode) { error_log("--- Scan IMAGES terminé ---"); }


### PR DESCRIPTION
## Summary
- release the image scan lock and surface a WP_Error when scheduling the next image batch fails
- remove the helper lock token option when scheduling fails and cover the behavior with a regression test

## Testing
- vendor/bin/phpunit tests/BlcScannerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d7d2537f04832ead75914b6423215a