### PR TITLE
Add capability check before saving settings

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -251,6 +251,15 @@ function blc_settings_page() {
     $get_timeout_limits  = $timeout_constraints['get'];
 
     if (isset($_POST['blc_save_settings'])) {
+        if (!current_user_can('manage_options')) {
+            wp_die(
+                esc_html__(
+                    'Vous n\'avez pas l\'autorisation nécessaire pour modifier ces réglages.',
+                    'liens-morts-detector-jlg'
+                )
+            );
+        }
+
         check_admin_referer('blc_settings_nonce');
 
         $allowed_frequencies = array('daily', 'weekly', 'monthly');


### PR DESCRIPTION
## Summary
- add a manage_options capability check to the settings submission handler to prevent unauthorized updates
- extend the settings page test harness to mock the new guard and cover the unauthorized path

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68d7fbfd7140832e867726ae57aca373