### PR TITLE
Handle activation schedule failure admin notices

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-activation.php
+++ b/liens-morts-detector-jlg/includes/blc-activation.php
@@ -498,3 +498,50 @@ function blc_deactivation($network_wide = false) {
         }
     }
 }
+
+/**
+ * Affiche une éventuelle notification d'échec de planification enregistrée lors de l'activation.
+ *
+ * Cette fonction récupère la notification stockée dans un transient ou une option et la supprime
+ * après l'affichage pour éviter les doublons.
+ */
+function blc_maybe_show_activation_schedule_notice() {
+    $notice = false;
+
+    if (function_exists('get_transient')) {
+        $notice = get_transient('blc_activation_schedule_failure');
+
+        if (false !== $notice) {
+            delete_transient('blc_activation_schedule_failure');
+        }
+    }
+
+    if (false === $notice || empty($notice)) {
+        $notice = get_option('blc_activation_schedule_failure');
+
+        if (!empty($notice)) {
+            delete_option('blc_activation_schedule_failure');
+        }
+    }
+
+    if (empty($notice) || !is_array($notice)) {
+        return;
+    }
+
+    $message = isset($notice['message']) ? (string) $notice['message'] : '';
+    if ($message === '') {
+        return;
+    }
+
+    $type = isset($notice['type']) ? strtolower((string) $notice['type']) : 'warning';
+    $allowed_types = array('error', 'warning', 'success', 'info');
+    if (!in_array($type, $allowed_types, true)) {
+        $type = 'warning';
+    }
+
+    printf(
+        '<div class="notice notice-%1$s is-dismissible"><p>%2$s</p></div>',
+        esc_attr($type),
+        wp_kses_post($message)
+    );
+}

--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -72,6 +72,10 @@ add_action('plugins_loaded', 'blc_maybe_upgrade_database');
 // Ajoute le menu et les pages dans l'administration
 add_action('admin_menu', 'blc_add_admin_menu');
 
+// Affiche la notification d'échec de planification lors de l'activation si nécessaire.
+add_action('admin_notices', 'blc_maybe_show_activation_schedule_notice');
+add_action('network_admin_notices', 'blc_maybe_show_activation_schedule_notice');
+
 // Ajoute nos planifications personnalisées (hebdomadaire, mensuelle) à WP-Cron
 add_filter('cron_schedules', 'blc_add_cron_schedules');
 


### PR DESCRIPTION
## Summary
- add a helper that surfaces the stored activation scheduling failure message once
- wire the helper into standard and network admin notice hooks so it runs in the back office

## Testing
- php -l liens-morts-detector-jlg/includes/blc-activation.php
- php -l liens-morts-detector-jlg/liens-morts-detector-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68dac8113ea4832e9e699e60b88349fb