### PR TITLE
Handle HEAD fallbacks for fast scan mode

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -1432,6 +1432,15 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
                         $wait_for_remote_slot();
                         $response = wp_safe_remote_head($normalized_url, $head_request_args);
                         $mark_remote_request_complete();
+
+                        if (!is_wp_error($response)) {
+                            $head_status = (int) wp_remote_retrieve_response_code($response);
+                            if (in_array($head_status, [403, 405, 501], true)) {
+                                $wait_for_remote_slot();
+                                $response = wp_safe_remote_get($normalized_url, $get_request_args);
+                                $mark_remote_request_complete();
+                            }
+                        }
                     }
 
                     if (is_wp_error($response)) {


### PR DESCRIPTION
## Summary
- add GET fallback handling for fast scans when HEAD requests return 403, 405, or 501
- add PHPUnit coverage to confirm fast mode avoids false positives after a HEAD 405 response

## Testing
- ./vendor/bin/phpunit --bootstrap vendor/autoload.php tests/BlcScannerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dbe8fc5674832e8299b5dbc9eadd2f