### PR TITLE
Handle expired image scan locks when timeout is non-positive

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -475,7 +475,17 @@ function blc_is_image_scan_lock_active(array $state, $timeout) {
         return false;
     }
 
-    return ($locked_at + $timeout) > time();
+    if ($locked_at <= 0) {
+        return false;
+    }
+
+    $expires_at = $locked_at + $timeout;
+
+    if ($expires_at <= 0) {
+        return false;
+    }
+
+    return $expires_at > time();
 }
 
 /**

--- a/tests/BlcScannerTest.php
+++ b/tests/BlcScannerTest.php
@@ -2615,6 +2615,29 @@ class BlcScannerTest extends TestCase
         });
     }
 
+    public function test_blc_is_image_scan_lock_active_treats_non_positive_timeout_as_expired(): void
+    {
+        $state = [
+            'token'     => 'lock-token',
+            'locked_at' => $this->utcNow - 30,
+        ];
+
+        $this->assertFalse(
+            blc_is_image_scan_lock_active($state, 0),
+            'A zero timeout should be treated as an expired image scan lock.'
+        );
+
+        $this->assertFalse(
+            blc_is_image_scan_lock_active($state, -5),
+            'Negative timeouts should force the image scan lock to be considered expired.'
+        );
+
+        $this->assertTrue(
+            blc_is_image_scan_lock_active($state, 60),
+            'Positive timeouts should keep recently refreshed locks active.'
+        );
+    }
+
     public function test_blc_perform_image_check_cleans_table_and_reschedules(): void
     {
         global $wpdb;


### PR DESCRIPTION
## Summary
- ensure the image scan lock helper treats non-positive timeouts and invalid timestamps as expired
- add a regression test covering zero and negative image scan lock timeouts

## Testing
- vendor/bin/phpunit tests/BlcScannerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dbf77ce1a4832e955139683bcccc46