### PR TITLE
Treat non-positive image scan lock timeouts as expired

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -467,11 +467,10 @@ function blc_is_image_scan_lock_active(array $state, $timeout) {
         return false;
     }
 
-    if (!is_int($timeout)) {
-        $timeout = (int) $timeout;
-    }
+    $timeout = (int) $timeout;
 
     if ($timeout <= 0) {
+        // A non-positive timeout disables the lock and should be treated as expired.
         return false;
     }
 

--- a/tests/BlcScannerTest.php
+++ b/tests/BlcScannerTest.php
@@ -2667,6 +2667,24 @@ class BlcScannerTest extends TestCase
         $this->assertSame($lock_state['token'], $this->updatedOptions['blc_image_scan_lock_token']);
     }
 
+    public function test_blc_is_image_scan_lock_active_treats_non_positive_timeout_as_expired(): void
+    {
+        $state = [
+            'token'     => 'token-zero-timeout',
+            'locked_at' => $this->utcNow,
+        ];
+
+        $this->assertFalse(
+            blc_is_image_scan_lock_active($state, 0),
+            'Zero timeout must be treated as an expired lock.'
+        );
+
+        $this->assertFalse(
+            blc_is_image_scan_lock_active($state, -15),
+            'Negative timeouts should also expire the lock.'
+        );
+    }
+
     public function test_blc_perform_image_check_reacquires_lock_when_timeout_is_zero(): void
     {
         global $wpdb;


### PR DESCRIPTION
## Summary
- ensure `blc_is_image_scan_lock_active` casts the timeout to an integer and treats non-positive values as expired locks
- add coverage verifying that zero or negative timeouts force the image scan to reacquire the lock

## Testing
- ./vendor/bin/phpunit tests/BlcScannerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dbf7745dd4832eb07597ac5b4602ac