### PR TITLE
Add search support to broken links list table

### DIFF
--- a/tests/AdminListTablesTest.php
+++ b/tests/AdminListTablesTest.php
@@ -141,6 +141,24 @@ class AdminListTablesTest extends TestCase
         $this->assertStringContainsString('OFFSET 0', $wpdb->last_get_results_query);
     }
 
+    public function test_links_prepare_items_adds_search_term_conditions(): void
+    {
+        global $wpdb;
+        $wpdb = new DummyWpdb();
+        $wpdb->get_var_return_values = [0];
+        $wpdb->results_to_return = [];
+
+        $_REQUEST['s'] = 'broken link';
+
+        $table = new \BLC_Links_List_Table();
+        $table->prepare_items();
+
+        $expected_like = "(url LIKE '%broken link%' OR anchor LIKE '%broken link%' OR post_title LIKE '%broken link%')";
+
+        $this->assertStringContainsString($expected_like, $wpdb->last_get_var_query);
+        $this->assertStringContainsString($expected_like, $wpdb->last_get_results_query);
+    }
+
     public function test_links_prepare_items_internal_filter_adds_like_condition(): void
     {
         global $wpdb;


### PR DESCRIPTION
## Summary
- render a search box for the broken links list table and capture the request term
- extend the list table queries to filter by the search term across url, anchor, and post title
- cover the new filtering logic with a PHPUnit test

## Testing
- ./vendor/bin/phpunit tests/AdminListTablesTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dc06f401cc832e8d70e963cd43ac30