### PR TITLE
Escape uninstall DROP TABLE statement

### DIFF
--- a/liens-morts-detector-jlg/uninstall.php
+++ b/liens-morts-detector-jlg/uninstall.php
@@ -36,7 +36,8 @@ $cleanup_site = static function () use ($options_to_delete) {
     }
 
     $table_name = $wpdb->prefix . 'blc_broken_links';
-    $wpdb->query("DROP TABLE IF EXISTS $table_name");
+    $escaped_table_name = '`' . str_replace('`', '``', $table_name) . '`';
+    $wpdb->query("DROP TABLE IF EXISTS $escaped_table_name");
 
     wp_clear_scheduled_hook('blc_check_links');
     wp_clear_scheduled_hook('blc_check_batch');

--- a/tests/UninstallTest.php
+++ b/tests/UninstallTest.php
@@ -64,5 +64,30 @@ class UninstallTest extends TestCase
         self::assertContains('blc_dataset_size_link', $deleted_site_options);
         self::assertContains('blc_dataset_size_image', $deleted_site_options);
     }
+
+    public function test_uninstall_drops_table_with_backticks(): void
+    {
+        Functions\when('delete_option')->justReturn();
+        Functions\when('delete_site_option')->justReturn();
+        Functions\when('is_multisite')->justReturn(false);
+        Functions\when('wp_clear_scheduled_hook')->justReturn();
+
+        global $wpdb;
+
+        $wpdb = new class {
+            public string $prefix = 'wp-test_';
+
+            public array $queries = [];
+
+            public function query(string $sql): void
+            {
+                $this->queries[] = $sql;
+            }
+        };
+
+        require __DIR__ . '/../liens-morts-detector-jlg/uninstall.php';
+
+        self::assertSame(['DROP TABLE IF EXISTS `wp-test_blc_broken_links`'], $wpdb->queries);
+    }
 }
 


### PR DESCRIPTION
## Summary
- escape the uninstall table name with backticks while guarding embedded backticks
- add coverage ensuring the uninstall query includes the backticked table name when the prefix contains a hyphen

## Testing
- ./vendor/bin/phpunit tests/UninstallTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dc06f08b64832eae42a5dcfb5d34ac