### PR TITLE
Escape uninstall drop table name

### DIFF
--- a/liens-morts-detector-jlg/uninstall.php
+++ b/liens-morts-detector-jlg/uninstall.php
@@ -36,8 +36,8 @@ $cleanup_site = static function () use ($options_to_delete) {
     }
 
     $table_name = $wpdb->prefix . 'blc_broken_links';
-    $escaped_table_name = '`' . str_replace('`', '``', $table_name) . '`';
-    $wpdb->query("DROP TABLE IF EXISTS $escaped_table_name");
+    $escaped_table_name = str_replace('`', '``', $table_name);
+    $wpdb->query(sprintf('DROP TABLE IF EXISTS `%s`', $escaped_table_name));
 
     wp_clear_scheduled_hook('blc_check_links');
     wp_clear_scheduled_hook('blc_check_batch');

--- a/tests/UninstallTest.php
+++ b/tests/UninstallTest.php
@@ -75,6 +75,31 @@ class UninstallTest extends TestCase
         global $wpdb;
 
         $wpdb = new class {
+            public string $prefix = 'wp_';
+
+            public array $queries = [];
+
+            public function query(string $sql): void
+            {
+                $this->queries[] = $sql;
+            }
+        };
+
+        require __DIR__ . '/../liens-morts-detector-jlg/uninstall.php';
+
+        self::assertSame(['DROP TABLE IF EXISTS `wp_blc_broken_links`'], $wpdb->queries);
+    }
+
+    public function test_uninstall_drops_table_with_backticks_when_prefix_contains_dash(): void
+    {
+        Functions\when('delete_option')->justReturn();
+        Functions\when('delete_site_option')->justReturn();
+        Functions\when('is_multisite')->justReturn(false);
+        Functions\when('wp_clear_scheduled_hook')->justReturn();
+
+        global $wpdb;
+
+        $wpdb = new class {
             public string $prefix = 'wp-test_';
 
             public array $queries = [];


### PR DESCRIPTION
## Summary
- ensure the uninstall routine wraps the broken links table name in escaped backticks before issuing DROP TABLE
- extend the uninstall test coverage to confirm the query is properly quoted for standard and dash-containing table prefixes

## Testing
- ./vendor/bin/phpunit --filter UninstallTest tests

------
https://chatgpt.com/codex/tasks/task_e_68dc12f3a418832eacb2d9487eb3a3d9