### PR TITLE
Internationalize anchor placeholder label

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -1357,7 +1357,7 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
 
                 $anchor_text = wp_strip_all_tags($link_node->textContent);
                 $anchor_text = trim(preg_replace('/\s+/u', ' ', $anchor_text));
-                if ($anchor_text === '') { $anchor_text = '[Lien sans texte]'; }
+                if ($anchor_text === '') { $anchor_text = sprintf('[%s]', __('Lien sans texte', 'liens-morts-detector-jlg')); }
 
                 $url_for_storage    = blc_prepare_url_for_storage($original_url);
                 $anchor_for_storage = blc_prepare_text_field_for_storage($anchor_text);

--- a/liens-morts-detector-jlg/languages/liens-morts-detector-jlg.pot
+++ b/liens-morts-detector-jlg/languages/liens-morts-detector-jlg.pot
@@ -15,6 +15,10 @@ msgstr ""
 msgid "Liens Morts"
 msgstr ""
 
+#: includes/blc-scanner.php:1360
+msgid "Lien sans texte"
+msgstr ""
+
 #: includes/blc-admin-pages.php:22 includes/blc-admin-pages.php:23
 msgid "Liens Cassés"
 msgstr ""


### PR DESCRIPTION
## Summary
- replace the hard coded placeholder used for empty anchor text with a translatable string
- add the new string to the POT catalogue for translators

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc2309b49c832e9f2a81d304e0e286