### PR TITLE
Add customizable user agent for remote link checks

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -1595,6 +1595,7 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
                 $head_request_disallowed = false;
                 if (!$should_use_cache) {
                     $head_request_args = [
+                        'user-agent'          => blc_get_http_user_agent(),
                         'timeout'             => $head_request_timeout,
                         'limit_response_size' => 1024,
                         'redirection'         => 5,
@@ -1602,7 +1603,7 @@ function blc_perform_check($batch = 0, $is_full_scan = false, $bypass_rest_windo
 
                     $get_request_args = [
                         'timeout'             => $get_request_timeout,
-                        'user-agent'          => 'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/115.0',
+                        'user-agent'          => blc_get_http_user_agent(),
                         'method'              => 'GET',
                         'limit_response_size' => 131072,
                     ];

--- a/tests/BlcScannerTest.php
+++ b/tests/BlcScannerTest.php
@@ -562,6 +562,20 @@ class BlcScannerTest extends TestCase
      */
     private function mockHttpRequest(string $method, string $url, array $args = [])
     {
+        if ($method === 'HEAD' || $method === 'GET') {
+            $expected_user_agent = \blc_get_http_user_agent();
+
+            if (!array_key_exists('user-agent', $args)) {
+                $this->fail('HTTP requests must include the plugin user agent.');
+            }
+
+            $this->assertSame(
+                $expected_user_agent,
+                (string) $args['user-agent'],
+                'HTTP requests should use the plugin user agent.'
+            );
+        }
+
         $this->httpRequests[] = ['method' => $method, 'url' => $url, 'args' => $args];
         $key = $method . ' ' . $url;
 
@@ -1399,12 +1413,16 @@ class BlcScannerTest extends TestCase
         $this->assertSame('http://example.com/no-head', $headRequest['url']);
         $this->assertArrayHasKey('limit_response_size', $headRequest['args']);
         $this->assertSame(1024, $headRequest['args']['limit_response_size']);
+        $this->assertArrayHasKey('user-agent', $headRequest['args']);
+        $this->assertSame(\blc_get_http_user_agent(), $headRequest['args']['user-agent']);
 
         $getRequest = $this->httpRequests[1];
         $this->assertSame('GET', $getRequest['method']);
         $this->assertSame('http://example.com/no-head', $getRequest['url']);
         $this->assertArrayHasKey('limit_response_size', $getRequest['args']);
         $this->assertSame(131072, $getRequest['args']['limit_response_size']);
+        $this->assertArrayHasKey('user-agent', $getRequest['args']);
+        $this->assertSame(\blc_get_http_user_agent(), $getRequest['args']['user-agent']);
 
         $this->assertCount(0, $wpdb->inserted, 'Successful GET fallback should prevent false positives.');
     }


### PR DESCRIPTION
## Summary
- add a reusable helper to build a descriptive plugin HTTP user agent string with filtering support
- update link scanner requests to rely on the helper and drop the previous hard-coded browser user agent
- tighten Brain Monkey stubs to assert the new user agent is used during tests

## Testing
- vendor/bin/phpunit tests/BlcScannerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dc314d1194832eba424d7ebda8915c