### PR TITLE
Ensure attachment files exist before marking internal URLs healthy

### DIFF
--- a/patchwork.json
+++ b/patchwork.json
@@ -4,6 +4,7 @@
         "time",
         "dns_get_record",
         "gethostbynamel",
-        "error_log"
+        "error_log",
+        "file_exists"
     ]
 }


### PR DESCRIPTION
## Summary
- verify attachment targets returned by internal URL resolution to ensure their files still exist
- extend test scaffolding to stub attachment metadata and filesystem lookups
- cover missing attachment files with a regression test that exercises dataset bookkeeping

## Testing
- ./vendor/bin/phpunit --bootstrap vendor/autoload.php tests

------
https://chatgpt.com/codex/tasks/task_e_68dc43cfc9b0832ebeb2921edeae99ed