### PR TITLE
Improve responsive admin tables

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -52,3 +52,80 @@
     color: #1d2327; /* Couleur noire par défaut de l'admin WP */
     visibility: visible; /* S'assurer que le texte est toujours visible */
 }
+
+/* Forcer la casse des URL longues pour éviter les débordements */
+.wp-list-table td.column-url a,
+.wp-list-table td.column-image_details a {
+    word-break: break-word;
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 782px) {
+    .wp-list-table {
+        display: block;
+        width: 100%;
+        overflow-x: auto;
+    }
+
+    .wp-list-table thead,
+    .wp-list-table tfoot {
+        display: none;
+    }
+
+    .wp-list-table tbody {
+        display: block;
+    }
+
+    .wp-list-table tr {
+        display: block;
+        margin-bottom: 16px;
+        border: 1px solid #c3c4c7;
+        border-radius: 4px;
+        background: #fff;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+    }
+
+    .wp-list-table td {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        padding: 12px 16px;
+        align-items: baseline;
+        border-top: 1px solid #dcdcde;
+    }
+
+    .wp-list-table td:first-child {
+        border-top: none;
+    }
+
+    .wp-list-table td::before {
+        content: attr(data-colname);
+        flex: 0 0 40%;
+        font-weight: 600;
+        color: #1d2327;
+    }
+
+    .wp-list-table td.column-primary {
+        display: block;
+        padding-bottom: 8px;
+    }
+
+    .wp-list-table td.column-primary::before {
+        display: block;
+        margin-bottom: 6px;
+    }
+
+    .wp-list-table td.column-primary .row-actions {
+        margin-top: 8px;
+        padding-top: 8px;
+        border-top: 1px solid #dcdcde;
+    }
+
+    .wp-list-table td.column-primary .row-actions::before {
+        content: none;
+    }
+
+    .wp-list-table td.column-primary .row-actions span {
+        margin-right: 12px;
+    }
+}


### PR DESCRIPTION
## Summary
- allow long URLs to wrap within the broken links and images tables
- add a mobile layout that renders wp-list-table entries as stacked cards below 782px

## Testing
- not run (WordPress admin environment unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc5cafdc00832ea4f8d3e7896d206c