### PR TITLE
Replace admin prompts with modal dialog

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -52,3 +52,145 @@
     color: #1d2327; /* Couleur noire par défaut de l'admin WP */
     visibility: visible; /* S'assurer que le texte est toujours visible */
 }
+
+/* Styles pour la modale d'édition/suppression de liens */
+.blc-modal {
+    position: fixed;
+    inset: 0;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    background-color: rgba(29, 35, 39, 0.55);
+    z-index: 100000; /* Au-dessus de la barre d'admin WP */
+    padding: 20px;
+}
+
+.blc-modal.is-open {
+    display: flex;
+}
+
+.blc-modal__dialog {
+    position: relative;
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+    padding: 24px;
+    width: 100%;
+    max-width: 480px;
+}
+
+.blc-modal__title {
+    margin-top: 0;
+    margin-bottom: 12px;
+}
+
+.blc-modal__message {
+    margin-bottom: 16px;
+    color: #1d2327;
+    white-space: pre-line;
+}
+
+.blc-modal__error {
+    display: none;
+    margin-bottom: 16px;
+    padding: 10px 12px;
+    border-radius: 4px;
+    background-color: #fef2f2;
+    color: #b32d2e;
+    border: 1px solid #f0c9c9;
+}
+
+.blc-modal__error.is-visible {
+    display: block;
+}
+
+.blc-modal__field {
+    margin-bottom: 20px;
+}
+
+.blc-modal__field.is-hidden {
+    display: none;
+}
+
+.blc-modal__label {
+    display: block;
+    margin-bottom: 6px;
+    font-weight: 600;
+}
+
+.blc-modal__input {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid #c3c4c7;
+    border-radius: 4px;
+    font-size: 14px;
+}
+
+.blc-modal__actions {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+}
+
+.blc-modal__actions .button {
+    min-width: 120px;
+}
+
+.blc-modal__close {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    border: none;
+    background: transparent;
+    color: #1d2327;
+    font-size: 24px;
+    cursor: pointer;
+}
+
+.blc-modal__close:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+.blc-modal.is-submitting .button,
+.blc-modal.is-submitting .blc-modal__close {
+    cursor: progress;
+}
+
+body.blc-modal-open {
+    overflow: hidden;
+}
+
+@media (max-width: 782px) {
+    .blc-modal {
+        padding: 0;
+    }
+
+    .blc-modal__dialog {
+        height: 100%;
+        max-width: none;
+        border-radius: 0;
+        padding: 24px 20px 28px;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+    }
+
+    .blc-modal__actions {
+        flex-direction: column-reverse;
+        gap: 10px;
+    }
+
+    .blc-modal__actions .button {
+        width: 100%;
+        min-width: 0;
+        padding: 12px;
+        text-align: center;
+        font-size: 16px;
+    }
+
+    .blc-modal__close {
+        top: 14px;
+        right: 14px;
+    }
+}

--- a/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
+++ b/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
@@ -1,9 +1,211 @@
 jQuery(document).ready(function($) {
-    var messages = window.blcAdminMessages || {};
-    var editPromptMessage = messages.editPromptMessage || "Entrez la nouvelle URL pour :\n%s";
-    var editPromptDefault = messages.editPromptDefault || 'https://';
-    var unlinkConfirmation = messages.unlinkConfirmation || "Êtes-vous sûr de vouloir supprimer ce lien ? Le texte sera conservé.";
-    var errorPrefix = messages.errorPrefix || 'Erreur : ';
+    var defaultMessages = {
+        editPromptMessage: "Entrez la nouvelle URL pour :\n%s",
+        editPromptDefault: 'https://',
+        unlinkConfirmation: "Êtes-vous sûr de vouloir supprimer ce lien ? Le texte sera conservé.",
+        errorPrefix: 'Erreur : ',
+        editModalTitle: 'Modifier le lien',
+        editModalLabel: 'Nouvelle URL',
+        editModalConfirm: 'Mettre à jour',
+        unlinkModalTitle: 'Supprimer le lien',
+        unlinkModalConfirm: 'Supprimer',
+        cancelButton: 'Annuler',
+        closeLabel: 'Fermer la fenêtre modale',
+        emptyUrlMessage: 'Veuillez saisir une URL.',
+        invalidUrlMessage: 'Veuillez saisir une URL valide.',
+        sameUrlMessage: "La nouvelle URL doit être différente de l'URL actuelle.",
+        genericError: 'Une erreur est survenue. Veuillez réessayer.'
+    };
+
+    var messages = $.extend({}, defaultMessages, window.blcAdminMessages || {});
+
+    var modal = (function() {
+        var $modal = $('#blc-modal');
+
+        if (!$modal.length) {
+            return {
+                open: function() {},
+                close: function() {},
+                helpers: {
+                    showError: function() {},
+                    clearError: function() {},
+                    setSubmitting: function() {},
+                    close: function() {}
+                }
+            };
+        }
+
+        var $title = $modal.find('.blc-modal__title');
+        var $message = $modal.find('.blc-modal__message');
+        var $error = $modal.find('.blc-modal__error');
+        var $field = $modal.find('.blc-modal__field');
+        var $label = $modal.find('.blc-modal__label');
+        var $input = $modal.find('.blc-modal__input');
+        var $confirm = $modal.find('.blc-modal__confirm');
+        var $cancel = $modal.find('.blc-modal__cancel');
+        var $close = $modal.find('.blc-modal__close');
+
+        var state = {
+            isOpen: false,
+            onConfirm: null,
+            showInput: true,
+            isSubmitting: false
+        };
+
+        function clearError() {
+            $error.removeClass('is-visible').text('');
+        }
+
+        function showError(message) {
+            if (message) {
+                $error.text(message).addClass('is-visible');
+            } else {
+                clearError();
+            }
+        }
+
+        function setSubmitting(isSubmitting) {
+            state.isSubmitting = isSubmitting;
+            $confirm.prop('disabled', isSubmitting);
+            $cancel.prop('disabled', isSubmitting);
+            $close.prop('disabled', isSubmitting);
+            $modal.toggleClass('is-submitting', isSubmitting);
+        }
+
+        function close() {
+            if (!state.isOpen) {
+                return;
+            }
+
+            state.isOpen = false;
+            state.onConfirm = null;
+            state.showInput = true;
+
+            $modal.removeClass('is-open').attr('aria-hidden', 'true');
+            $('body').removeClass('blc-modal-open');
+
+            setSubmitting(false);
+            clearError();
+
+            $title.text('');
+            $message.text('');
+            $label.text('');
+            $input.val('').attr('type', 'url');
+            $field.removeClass('is-hidden');
+        }
+
+        function open(options) {
+            if (!$modal.length) {
+                return;
+            }
+
+            options = options || {};
+
+            state.onConfirm = typeof options.onConfirm === 'function' ? options.onConfirm : null;
+            state.showInput = options.showInput !== false;
+
+            $title.text(options.title || '');
+            $message.text(options.message || '');
+
+            var labelText = options.label || (state.showInput ? messages.editModalLabel : '');
+            $label.text(labelText);
+
+            var placeholder = options.placeholder || messages.editPromptDefault || '';
+            $input.attr('placeholder', placeholder);
+
+            if (state.showInput) {
+                $field.removeClass('is-hidden');
+                $input.val(options.defaultValue || '').attr('type', options.inputType || 'url');
+            } else {
+                $field.addClass('is-hidden');
+                $input.val('');
+            }
+
+            var confirmText = options.confirmText;
+            if (!confirmText) {
+                confirmText = state.showInput ? messages.editModalConfirm : messages.unlinkModalConfirm;
+            }
+            $confirm.text(confirmText || messages.editModalConfirm || 'Confirmer');
+
+            $cancel.text(options.cancelText || messages.cancelButton || 'Annuler');
+            $close.attr('aria-label', options.closeLabel || messages.closeLabel || 'Fermer');
+
+            clearError();
+            setSubmitting(false);
+
+            $modal.addClass('is-open').attr('aria-hidden', 'false');
+            $('body').addClass('blc-modal-open');
+            state.isOpen = true;
+
+            window.setTimeout(function() {
+                if (state.showInput) {
+                    $input.trigger('focus').select();
+                } else {
+                    $confirm.trigger('focus');
+                }
+            }, 10);
+        }
+
+        var helpers = {
+            showError: showError,
+            clearError: clearError,
+            setSubmitting: setSubmitting,
+            close: close
+        };
+
+        $confirm.on('click', function() {
+            if (!state.isOpen || state.isSubmitting) {
+                return;
+            }
+
+            var value = state.showInput ? $input.val() : '';
+
+            if (state.onConfirm) {
+                state.onConfirm(value, helpers);
+            }
+        });
+
+        $cancel.on('click', function() {
+            if (!state.isSubmitting) {
+                close();
+            }
+        });
+
+        $close.on('click', function() {
+            if (!state.isSubmitting) {
+                close();
+            }
+        });
+
+        $modal.on('click', function(event) {
+            if (event.target === $modal[0] && !state.isSubmitting) {
+                close();
+            }
+        });
+
+        $(document).on('keydown', function(event) {
+            if (event.key === 'Escape' && state.isOpen && !state.isSubmitting) {
+                close();
+            }
+        });
+
+        $input.on('keydown', function(event) {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+                $confirm.trigger('click');
+            }
+        });
+
+        return {
+            open: open,
+            close: close,
+            helpers: helpers
+        };
+    })();
+
+    function hasWhitespace(value) {
+        return /\s/.test(value);
+    }
 
     /**
      * Gère le clic sur le bouton "Modifier le lien".
@@ -25,35 +227,67 @@ jQuery(document).ready(function($) {
         }
         var nonce = linkElement.data('nonce');
 
-        // Affiche une boîte de dialogue pour demander la nouvelle URL
-        var promptMessage = editPromptMessage.replace('%s', oldUrl);
-        var newUrl = prompt(promptMessage, editPromptDefault);
+        var promptMessage = (messages.editPromptMessage || '').replace('%s', oldUrl || '');
 
-        // Si l'utilisateur a entré une nouvelle URL et n'a pas annulé
-        if (newUrl && newUrl !== oldUrl) {
-            // Grise la ligne pour montrer qu'une action est en cours
-            linkElement.closest('tr').css('opacity', 0.5);
+        modal.open({
+            title: messages.editModalTitle,
+            message: promptMessage,
+            label: messages.editModalLabel,
+            defaultValue: oldUrl || messages.editPromptDefault,
+            placeholder: messages.editPromptDefault,
+            confirmText: messages.editModalConfirm,
+            cancelText: messages.cancelButton,
+            closeLabel: messages.closeLabel,
+            onConfirm: function(inputValue, helpers) {
+                var trimmedValue = (inputValue || '').trim();
 
-            // Envoie la requête AJAX à WordPress
-            $.post(ajaxurl, {
-                action: 'blc_edit_link',
-                post_id: postId,
-                row_id: rowId,
-                occurrence_index: occurrenceIndex,
-                old_url: oldUrl,
-                new_url: newUrl,
-                _ajax_nonce: nonce
-            }, function(response) {
-                if (response.success) {
-                    // Si la modification a réussi, on fait disparaître la ligne
-                    linkElement.closest('tr').fadeOut(300, function() { $(this).remove(); });
-                } else {
-                    // S'il y a une erreur, on l'affiche et on remet la ligne en état normal
-                    alert(errorPrefix + response.data.message);
-                    linkElement.closest('tr').css('opacity', 1);
+                if (!trimmedValue) {
+                    helpers.showError(messages.emptyUrlMessage);
+                    return;
                 }
-            });
-        }
+
+                if (hasWhitespace(trimmedValue)) {
+                    helpers.showError(messages.invalidUrlMessage);
+                    return;
+                }
+
+                if (trimmedValue === oldUrl) {
+                    helpers.showError(messages.sameUrlMessage);
+                    return;
+                }
+
+                helpers.setSubmitting(true);
+
+                var row = linkElement.closest('tr');
+                row.css('opacity', 0.5);
+
+                $.post(ajaxurl, {
+                    action: 'blc_edit_link',
+                    post_id: postId,
+                    row_id: rowId,
+                    occurrence_index: occurrenceIndex,
+                    old_url: oldUrl,
+                    new_url: trimmedValue,
+                    _ajax_nonce: nonce
+                }).done(function(response) {
+                    if (response && response.success) {
+                        helpers.close();
+                        row.fadeOut(300, function() { $(this).remove(); });
+                    } else {
+                        var errorMessage = response && response.data && response.data.message
+                            ? response.data.message
+                            : messages.genericError;
+                        helpers.setSubmitting(false);
+                        helpers.showError((messages.errorPrefix || '') + errorMessage);
+                        row.css('opacity', 1);
+                    }
+                }).fail(function() {
+                    helpers.setSubmitting(false);
+                    helpers.showError(messages.genericError);
+                    row.css('opacity', 1);
+                });
+            }
+        });
     });
 
     /**
@@ -75,25 +309,49 @@ jQuery(document).ready(function($) {
         }
         var nonce = linkElement.data('nonce');
 
-        // Demande une confirmation avant de supprimer le lien
-        if (confirm(unlinkConfirmation)) {
-            linkElement.closest('tr').css('opacity', 0.5);
-
-            $.post(ajaxurl, {
-                action: 'blc_unlink',
-                post_id: postId,
-                row_id: rowId,
-                occurrence_index: occurrenceIndex,
-                url_to_unlink: urlToUnlink,
-                _ajax_nonce: nonce
-            }, function(response) {
-                if (response.success) {
-                    linkElement.closest('tr').fadeOut(300, function() { $(this).remove(); });
-                } else {
-                    alert(errorPrefix + response.data.message);
-                    linkElement.closest('tr').css('opacity', 1);
-                }
-            });
+        var unlinkMessage = messages.unlinkConfirmation || '';
+        if (urlToUnlink) {
+            unlinkMessage = unlinkMessage ? unlinkMessage + '\n' + urlToUnlink : urlToUnlink;
         }
+
+        modal.open({
+            title: messages.unlinkModalTitle,
+            message: unlinkMessage,
+            showInput: false,
+            confirmText: messages.unlinkModalConfirm,
+            cancelText: messages.cancelButton,
+            closeLabel: messages.closeLabel,
+            onConfirm: function(_value, helpers) {
+                helpers.setSubmitting(true);
+
+                var row = linkElement.closest('tr');
+                row.css('opacity', 0.5);
+
+                $.post(ajaxurl, {
+                    action: 'blc_unlink',
+                    post_id: postId,
+                    row_id: rowId,
+                    occurrence_index: occurrenceIndex,
+                    url_to_unlink: urlToUnlink,
+                    _ajax_nonce: nonce
+                }).done(function(response) {
+                    if (response && response.success) {
+                        helpers.close();
+                        row.fadeOut(300, function() { $(this).remove(); });
+                    } else {
+                        var errorMessage = response && response.data && response.data.message
+                            ? response.data.message
+                            : messages.genericError;
+                        helpers.setSubmitting(false);
+                        helpers.showError((messages.errorPrefix || '') + errorMessage);
+                        row.css('opacity', 1);
+                    }
+                }).fail(function() {
+                    helpers.setSubmitting(false);
+                    helpers.showError(messages.genericError);
+                    row.css('opacity', 1);
+                });
+            }
+        });
     });
 });

--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -107,6 +107,24 @@ function blc_dashboard_links_page() {
     $list_table = new BLC_Links_List_Table();
     $list_table->prepare_items();
     ?>
+    <div id="blc-modal" class="blc-modal" role="presentation" aria-hidden="true">
+        <div class="blc-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="blc-modal-title">
+            <button type="button" class="blc-modal__close" aria-label="<?php echo esc_attr__('Fermer la fenêtre modale', 'liens-morts-detector-jlg'); ?>">
+                <span aria-hidden="true">&times;</span>
+            </button>
+            <h2 id="blc-modal-title" class="blc-modal__title"></h2>
+            <p class="blc-modal__message"></p>
+            <div class="blc-modal__error" role="alert" aria-live="assertive"></div>
+            <div class="blc-modal__field">
+                <label for="blc-modal-url" class="blc-modal__label"></label>
+                <input type="url" id="blc-modal-url" class="blc-modal__input" placeholder="<?php echo esc_attr__('https://', 'liens-morts-detector-jlg'); ?>">
+            </div>
+            <div class="blc-modal__actions">
+                <button type="button" class="button button-secondary blc-modal__cancel"><?php esc_html_e('Annuler', 'liens-morts-detector-jlg'); ?></button>
+                <button type="button" class="button button-primary blc-modal__confirm"><?php esc_html_e('Confirmer', 'liens-morts-detector-jlg'); ?></button>
+            </div>
+        </div>
+    </div>
     <div class="wrap">
         <h1><?php esc_html_e('Rapport des Liens Cassés', 'liens-morts-detector-jlg'); ?></h1>
         <div class="blc-stats-box">

--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -131,6 +131,17 @@ function blc_enqueue_admin_assets($hook) {
             'editPromptDefault'  => __('https://', 'liens-morts-detector-jlg'),
             'unlinkConfirmation' => __('Êtes-vous sûr de vouloir supprimer ce lien ? Le texte sera conservé.', 'liens-morts-detector-jlg'),
             'errorPrefix'        => __('Erreur : ', 'liens-morts-detector-jlg'),
+            'editModalTitle'     => __('Modifier le lien', 'liens-morts-detector-jlg'),
+            'editModalLabel'     => __('Nouvelle URL', 'liens-morts-detector-jlg'),
+            'editModalConfirm'   => __('Mettre à jour', 'liens-morts-detector-jlg'),
+            'unlinkModalTitle'   => __('Supprimer le lien', 'liens-morts-detector-jlg'),
+            'unlinkModalConfirm' => __('Supprimer', 'liens-morts-detector-jlg'),
+            'cancelButton'       => __('Annuler', 'liens-morts-detector-jlg'),
+            'closeLabel'         => __('Fermer la fenêtre modale', 'liens-morts-detector-jlg'),
+            'emptyUrlMessage'    => __('Veuillez saisir une URL.', 'liens-morts-detector-jlg'),
+            'invalidUrlMessage'  => __('Veuillez saisir une URL valide.', 'liens-morts-detector-jlg'),
+            'sameUrlMessage'     => __('La nouvelle URL doit être différente de l\'URL actuelle.', 'liens-morts-detector-jlg'),
+            'genericError'       => __('Une erreur est survenue. Veuillez réessayer.', 'liens-morts-detector-jlg'),
         )
     );
 }


### PR DESCRIPTION
## Summary
- add a reusable modal markup on the broken links report page for link editing and unlinking actions
- refactor the admin JavaScript to open the modal with validation instead of using prompt/confirm dialogs and show inline errors
- style the modal for desktop and mobile layouts and expose the related strings through localized script data

## Testing
- php -l liens-morts-detector-jlg/includes/blc-admin-pages.php
- php -l liens-morts-detector-jlg/liens-morts-detector-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68dc5cb5a5fc832ea3ac410ca456eee7