### PR TITLE
Improve responsive layout of admin stats box

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -12,6 +12,7 @@
 .blc-stats-box {
     display: flex;
     gap: 20px;
+    flex-wrap: wrap;
     background-color: #fff;
     border: 1px solid #c3c4c7;
     padding: 20px;
@@ -35,6 +36,19 @@
 .blc-stat-label {
     font-size: 1em;
     color: #50575e;
+}
+
+@media (max-width: 782px) {
+    .blc-stats-box {
+        flex-direction: column;
+        gap: 16px;
+    }
+
+    .blc-stat {
+        width: 100%;
+        flex: 1 1 100%;
+        padding: 12px 0;
+    }
 }
 
 /* Style pour les icônes dans le tableau */


### PR DESCRIPTION
## Summary
- allow the statistics container to wrap onto multiple lines
- adjust the mobile layout so each statistic spans the full width with comfortable spacing

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68dc5caf308c832ebca3551e74cd62b4