### PR TITLE
Improve responsive layout for admin link tables

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -57,6 +57,86 @@
     margin-right: 4px;
 }
 
+.wp-list-table td.column-url a,
+.wp-list-table td.column-image_details a {
+    word-break: break-word;
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 782px) {
+    .wp-list-table {
+        display: block;
+        width: 100%;
+        border-spacing: 0;
+    }
+
+    .wp-list-table thead,
+    .wp-list-table tfoot {
+        display: none;
+    }
+
+    .wp-list-table tbody {
+        display: block;
+        width: 100%;
+    }
+
+    .wp-list-table tr {
+        display: block;
+        width: 100%;
+        margin-bottom: 16px;
+        border: 1px solid #dcdcde;
+        border-radius: 6px;
+        background: #fff;
+        padding: 12px 16px;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+    }
+
+    .wp-list-table tr:last-child {
+        margin-bottom: 0;
+    }
+
+    .wp-list-table td {
+        display: flex;
+        width: 100%;
+        padding: 8px 0;
+        gap: 8px;
+        align-items: flex-start;
+        box-sizing: border-box;
+    }
+
+    .wp-list-table td::before {
+        content: attr(data-colname) ":";
+        font-weight: 600;
+        color: #50575e;
+        flex: 0 0 120px;
+        max-width: 40%;
+        text-transform: none;
+        letter-spacing: 0;
+    }
+
+    .wp-list-table td.column-primary {
+        flex-direction: column;
+        gap: 4px;
+    }
+
+    .wp-list-table td.column-primary::before {
+        flex: none;
+        max-width: none;
+    }
+
+    .wp-list-table td .row-actions {
+        margin-top: 6px;
+        position: static;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .wp-list-table td .row-actions span {
+        display: inline-flex;
+    }
+}
+
 /*
  * MODIFIÉ : Style pour le texte de l'ancre du lien
  * On utilise un sélecteur plus spécifique pour forcer la couleur noire


### PR DESCRIPTION
## Summary
- add responsive card-style layout for admin list tables on small screens
- ensure long URLs in link and image columns wrap within their cells

## Testing
- not run (environment not available)

------
https://chatgpt.com/codex/tasks/task_e_68dcf755e034832eb25a7892861e4789