### PR TITLE
Improve accessibility for rest window time inputs

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -658,9 +658,11 @@ function blc_settings_page() {
                         <th scope="row"><label for="blc_rest_start_hour"><?php esc_html_e('😴 Plage horaire de repos', 'liens-morts-detector-jlg'); ?></label></th>
                         <td>
                             <?php esc_html_e('Ne pas lancer de scan entre', 'liens-morts-detector-jlg'); ?>
-                            <input type="time" name="blc_rest_start_hour" value="<?php echo esc_attr($rest_start_hour); ?>">
+                            <label class="screen-reader-text" for="blc_rest_start_hour"><?php esc_html_e('Heure de début de la plage de repos', 'liens-morts-detector-jlg'); ?></label>
+                            <input type="time" name="blc_rest_start_hour" id="blc_rest_start_hour" value="<?php echo esc_attr($rest_start_hour); ?>">
                             <?php esc_html_e('et', 'liens-morts-detector-jlg'); ?>
-                            <input type="time" name="blc_rest_end_hour" value="<?php echo esc_attr($rest_end_hour); ?>">
+                            <label class="screen-reader-text" for="blc_rest_end_hour"><?php esc_html_e('Heure de fin de la plage de repos', 'liens-morts-detector-jlg'); ?></label>
+                            <input type="time" name="blc_rest_end_hour" id="blc_rest_end_hour" value="<?php echo esc_attr($rest_end_hour); ?>">
                             <p class="description">
                                 <?php
                                 $timezone_information = sprintf(


### PR DESCRIPTION
## Summary
- add explicit identifiers to the rest window time inputs
- provide screen-reader labels to associate each field with descriptive text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd0f2e27d0832e90f9df2abfb371c9