### PR TITLE
Improve mobile admin table label wrapping

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -108,8 +108,11 @@
         content: attr(data-colname) ":";
         font-weight: 600;
         color: #50575e;
-        flex: 0 0 120px;
-        max-width: 40%;
+        flex: 0 0 clamp(96px, 42%, 180px);
+        max-width: 100%;
+        white-space: normal;
+        word-break: break-word;
+        margin-right: 6px;
         text-transform: none;
         letter-spacing: 0;
     }


### PR DESCRIPTION
## Summary
- allow the mobile list table labels to wrap and use a clamp-based flex-basis so headings adapt to viewport width
- add spacing before values so long translations remain legible on narrow screens

## Testing
- Resized the sample table at 320 px, 414 px, and 768 px viewports to verify labels no longer overlap values

------
https://chatgpt.com/codex/tasks/task_e_68dd209a4278832eaa4f578ec9382885