### PR TITLE
Add responsive column labels to admin list tables

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -63,6 +63,19 @@
     overflow-wrap: anywhere;
 }
 
+.blc-column-label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    clip-path: inset(50%);
+    white-space: nowrap;
+    border: 0;
+}
+
 @media (max-width: 782px) {
     .wp-list-table {
         display: block;
@@ -101,17 +114,8 @@
         padding: 8px 0;
         gap: 8px;
         align-items: flex-start;
+        flex-direction: column;
         box-sizing: border-box;
-    }
-
-    .wp-list-table td::before {
-        content: attr(data-colname) ":";
-        font-weight: 600;
-        color: #50575e;
-        flex: 0 0 120px;
-        max-width: 40%;
-        text-transform: none;
-        letter-spacing: 0;
     }
 
     .wp-list-table td.column-primary {
@@ -119,9 +123,19 @@
         gap: 4px;
     }
 
-    .wp-list-table td.column-primary::before {
-        flex: none;
-        max-width: none;
+    .blc-column-label {
+        position: static;
+        width: auto;
+        height: auto;
+        margin: 0 0 4px;
+        overflow: visible;
+        clip: auto;
+        clip-path: none;
+        white-space: normal;
+        border: 0;
+        display: block;
+        font-weight: 600;
+        color: #50575e;
     }
 
     .wp-list-table td .row-actions {

--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -20,6 +20,7 @@ class BLC_Links_List_Table extends WP_List_Table {
 
     private $internal_url_condition_cache = null;
     private $search_term = null;
+    private $column_labels_cache = null;
 
     /**
      * Constructeur de la classe.
@@ -180,13 +181,14 @@ class BLC_Links_List_Table extends WP_List_Table {
             }
         }
 
-        $output = sprintf(
+        $output = $this->get_column_label_html('url');
+        $output .= sprintf(
             '<strong><a href="%s" target="_blank" rel="noopener noreferrer" title="%s">%s</a></strong>',
             esc_url($href),
             esc_attr__('Vérifier ce lien (nouvel onglet)', 'liens-morts-detector-jlg'),
             esc_html($original_url)
         );
-        
+
         // Les actions rapides (Modifier, Dissocier) sont ajoutées sous la colonne principale
         $output .= $this->row_actions($this->get_row_actions($item), true);
 
@@ -197,10 +199,12 @@ class BLC_Links_List_Table extends WP_List_Table {
      * Gère le rendu de la nouvelle colonne "Texte du lien".
      */
     protected function column_anchor_text($item) {
+        $output = $this->get_column_label_html('anchor_text');
+
         if (!empty($item['anchor'])) {
-            return '<em>' . esc_html($item['anchor']) . '</em>';
+            return $output . '<em>' . esc_html($item['anchor']) . '</em>';
         }
-        return esc_html__('—', 'liens-morts-detector-jlg'); // Affiche un tiret si aucun texte de lien n'a été capturé
+        return $output . esc_html__('—', 'liens-morts-detector-jlg'); // Affiche un tiret si aucun texte de lien n'a été capturé
     }
 
     /**
@@ -210,30 +214,30 @@ class BLC_Links_List_Table extends WP_List_Table {
         $edit_link = get_edit_post_link($item['post_id']);
 
         if ($edit_link === false) {
-            return esc_html__('—', 'liens-morts-detector-jlg');
+            return $this->get_column_label_html('post_title') . esc_html__('—', 'liens-morts-detector-jlg');
         }
 
-        return sprintf('<a href="%s">%s</a>', esc_url($edit_link), esc_html($item['post_title']));
+        return $this->get_column_label_html('post_title') . sprintf('<a href="%s">%s</a>', esc_url($edit_link), esc_html($item['post_title']));
     }
 
     protected function column_http_status($item) {
         $raw_status = $item['http_status'] ?? null;
 
         if ($raw_status === null || $raw_status === '') {
-            return esc_html__('—', 'liens-morts-detector-jlg');
+            return $this->get_column_label_html('http_status') . esc_html__('—', 'liens-morts-detector-jlg');
         }
 
         if (is_numeric($raw_status)) {
             $raw_status = (int) $raw_status;
         }
 
-        return esc_html((string) $raw_status);
+        return $this->get_column_label_html('http_status') . esc_html((string) $raw_status);
     }
 
     protected function column_last_checked_at($item) {
         $raw_value = $item['last_checked_at'] ?? '';
 
-        return $this->format_last_checked_at_for_display($raw_value);
+        return $this->get_column_label_html('last_checked_at') . $this->format_last_checked_at_for_display($raw_value);
     }
 
     /**
@@ -243,14 +247,31 @@ class BLC_Links_List_Table extends WP_List_Table {
         $edit_link = get_edit_post_link($item['post_id']);
 
         if ($edit_link === false) {
-            return esc_html__('—', 'liens-morts-detector-jlg');
+            return $this->get_column_label_html('actions') . esc_html__('—', 'liens-morts-detector-jlg');
         }
 
-        return sprintf(
+        return $this->get_column_label_html('actions') . sprintf(
             '<a href="%s" class="button button-secondary">%s</a>',
             esc_url($edit_link),
             esc_html__('Modifier l\'article', 'liens-morts-detector-jlg')
         );
+    }
+
+    protected function get_column_label_html($column_name) {
+        if ($this->column_labels_cache === null) {
+            $this->column_labels_cache = $this->get_columns();
+        }
+
+        $label = '';
+        if (is_array($this->column_labels_cache) && array_key_exists($column_name, $this->column_labels_cache)) {
+            $label = (string) $this->column_labels_cache[$column_name];
+        }
+
+        if ($label === '') {
+            return '';
+        }
+
+        return sprintf('<span class="blc-column-label">%s</span>', esc_html($label));
     }
 
     /**

--- a/tests/AdminListTablesTest.php
+++ b/tests/AdminListTablesTest.php
@@ -119,6 +119,11 @@ class AdminListTablesTest extends TestCase
             'post_title' => 'Sample Post',
         ]);
 
+        $columns = $table->get_columns();
+        $this->assertStringStartsWith(
+            sprintf('<span class="blc-column-label">%s</span>', $columns['url']),
+            $html
+        );
         $this->assertStringContainsString('href="https://example.com/post-12/images/photo.jpg"', $html);
         $this->assertStringContainsString('>images/photo.jpg<', $html);
     }
@@ -151,6 +156,9 @@ class AdminListTablesTest extends TestCase
         $this->assertArrayHasKey('http_status', $columns);
         $this->assertArrayHasKey('last_checked_at', $columns);
 
+        $http_status_label = sprintf('<span class="blc-column-label">%s</span>', $columns['http_status']);
+        $last_checked_label = sprintf('<span class="blc-column-label">%s</span>', $columns['last_checked_at']);
+
         $item = [
             'http_status'     => 410,
             'last_checked_at' => '1970-01-01 00:00:00',
@@ -159,8 +167,8 @@ class AdminListTablesTest extends TestCase
             'url'             => 'https://example.com',
         ];
 
-        $this->assertSame('410', $table->renderHttpStatus($item));
-        $this->assertSame('1970-01-01 00:00', $table->renderLastChecked($item));
+        $this->assertSame($http_status_label . '410', $table->renderHttpStatus($item));
+        $this->assertSame($last_checked_label . '1970-01-01 00:00', $table->renderLastChecked($item));
 
         $empty = [
             'http_status'     => null,
@@ -170,8 +178,8 @@ class AdminListTablesTest extends TestCase
             'url'             => 'https://example.com/empty',
         ];
 
-        $this->assertSame('—', $table->renderHttpStatus($empty));
-        $this->assertSame('—', $table->renderLastChecked($empty));
+        $this->assertSame($http_status_label . '—', $table->renderHttpStatus($empty));
+        $this->assertSame($last_checked_label . '—', $table->renderLastChecked($empty));
     }
 
     public function test_links_prepare_items_supports_injected_data_with_pagination(): void
@@ -223,6 +231,9 @@ class AdminListTablesTest extends TestCase
         $this->assertArrayHasKey('http_status', $columns);
         $this->assertArrayHasKey('last_checked_at', $columns);
 
+        $http_status_label = sprintf('<span class="blc-column-label">%s</span>', $columns['http_status']);
+        $last_checked_label = sprintf('<span class="blc-column-label">%s</span>', $columns['last_checked_at']);
+
         $item = [
             'http_status'     => null,
             'last_checked_at' => '1970-01-01 00:00:00',
@@ -232,8 +243,8 @@ class AdminListTablesTest extends TestCase
             'post_title'      => 'Gallery',
         ];
 
-        $this->assertSame('—', $table->renderHttpStatus($item));
-        $this->assertSame('1970-01-01 00:00', $table->renderLastChecked($item));
+        $this->assertSame($http_status_label . '—', $table->renderHttpStatus($item));
+        $this->assertSame($last_checked_label . '1970-01-01 00:00', $table->renderLastChecked($item));
 
         $missing = [
             'http_status'     => null,
@@ -244,8 +255,8 @@ class AdminListTablesTest extends TestCase
             'post_title'      => 'Empty',
         ];
 
-        $this->assertSame('—', $table->renderHttpStatus($missing));
-        $this->assertSame('—', $table->renderLastChecked($missing));
+        $this->assertSame($http_status_label . '—', $table->renderHttpStatus($missing));
+        $this->assertSame($last_checked_label . '—', $table->renderLastChecked($missing));
     }
 
     public function test_links_prepare_items_adds_search_term_conditions(): void


### PR DESCRIPTION
## Summary
- add reusable helpers that inject column labels into the link and image list table cells
- update the admin stylesheet to hide column labels off-canvas on desktop and reveal them on narrow viewports
- adjust PHPUnit coverage to assert the new markup prefixes

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68dd203eee10832eb3919a687b8f1e3f