### PR TITLE
Add accessible announcements and focus handling for quick actions

### DIFF
--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -141,7 +141,8 @@ function blc_enqueue_admin_assets($hook) {
             'emptyUrlMessage'    => __('Veuillez saisir une URL.', 'liens-morts-detector-jlg'),
             'invalidUrlMessage'  => __('Veuillez saisir une URL valide.', 'liens-morts-detector-jlg'),
             'sameUrlMessage'     => __('La nouvelle URL doit être différente de l\'URL actuelle.', 'liens-morts-detector-jlg'),
-            'genericError'       => __('Une erreur est survenue. Veuillez réessayer.', 'liens-morts-detector-jlg'),
+            'genericError'        => __('Une erreur est survenue. Veuillez réessayer.', 'liens-morts-detector-jlg'),
+            'successAnnouncement' => __('Action effectuée avec succès. La ligne a été retirée de la liste.', 'liens-morts-detector-jlg'),
         )
     );
 }

--- a/tests/js/__tests__/blc-admin-scripts.test.js
+++ b/tests/js/__tests__/blc-admin-scripts.test.js
@@ -1,0 +1,127 @@
+const path = require('path');
+const $ = require('jquery');
+
+describe('blc-admin-scripts accessibility helper', () => {
+    let originalReady;
+    let originalFadeOut;
+    let originalVisible;
+    let originalHidden;
+
+    beforeEach(() => {
+        jest.resetModules();
+        document.body.innerHTML = `
+            <div>
+                <table>
+                    <tbody id="the-list">
+                        <tr id="row-1">
+                            <td><button type="button" class="blc-edit-link">Modifier</button></td>
+                        </tr>
+                        <tr id="row-2">
+                            <td><button type="button" class="blc-edit-link">Modifier</button></td>
+                        </tr>
+                    </tbody>
+                </table>
+                <div class="tablenav">
+                    <button type="button" id="post-query-submit">Filtrer</button>
+                </div>
+            </div>
+        `;
+
+        originalReady = $.fn.ready;
+        $.fn.ready = function(fn) {
+            fn.call(document, $);
+            return this;
+        };
+
+        originalVisible = $.expr.pseudos.visible;
+        originalHidden = $.expr.pseudos.hidden;
+        $.expr.pseudos.visible = () => true;
+        $.expr.pseudos.hidden = () => false;
+
+        originalFadeOut = $.fn.fadeOut;
+        $.fn.fadeOut = function(_duration, callback) {
+            if (typeof callback === 'function') {
+                callback.call(this);
+            }
+            return this;
+        };
+
+        window.blcAdminMessages = {
+            successAnnouncement: 'Action effectuée avec succès.'
+        };
+
+        window.wp = {
+            a11y: {
+                speak: jest.fn()
+            }
+        };
+
+        global.jQuery = $;
+        global.$ = $;
+        window.jQuery = $;
+        window.$ = $;
+
+        require(path.resolve(__dirname, '../../..', 'liens-morts-detector-jlg/assets/js/blc-admin-scripts.js'));
+    });
+
+    afterEach(() => {
+        delete window.blcAdminMessages;
+        delete window.blcAdmin;
+        delete window.wp;
+        delete global.jQuery;
+        delete global.$;
+        delete window.jQuery;
+        delete window.$;
+
+        if (originalReady) {
+            $.fn.ready = originalReady;
+        } else {
+            delete $.fn.ready;
+        }
+
+        if (originalFadeOut) {
+            $.fn.fadeOut = originalFadeOut;
+        } else {
+            delete $.fn.fadeOut;
+        }
+
+        if (originalVisible) {
+            $.expr.pseudos.visible = originalVisible;
+        } else {
+            delete $.expr.pseudos.visible;
+        }
+
+        if (originalHidden) {
+            $.expr.pseudos.hidden = originalHidden;
+        } else {
+            delete $.expr.pseudos.hidden;
+        }
+
+        jest.resetModules();
+
+        originalReady = undefined;
+        originalFadeOut = undefined;
+        originalVisible = undefined;
+        originalHidden = undefined;
+    });
+
+    it('announces success through wp.a11y.speak for successful responses', () => {
+        const row = $('#row-1');
+        const helpers = {
+            close: jest.fn()
+        };
+
+        window.blcAdmin.listActions.handleSuccessfulResponse(
+            {
+                success: true,
+                data: {
+                    announcement: 'La ligne a été mise à jour.'
+                }
+            },
+            row,
+            helpers
+        );
+
+        expect(window.wp.a11y.speak).toHaveBeenCalledWith('La ligne a été mise à jour.', 'polite');
+    });
+});


### PR DESCRIPTION
## Summary
- announce successful quick actions through the new accessibility helper and keep focus on the next relevant control
- expose a localized success announcement string for the JavaScript helper
- cover the accessibility helper with a Jest test that checks `wp.a11y.speak` usage on success

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd2ecac238832e8fa9793c113a4019