### PR TITLE
Add status-based filters to broken links table

### DIFF
--- a/tests/stubs/WP_List_Table.php
+++ b/tests/stubs/WP_List_Table.php
@@ -26,4 +26,24 @@ class WP_List_Table
             ? (int) $_REQUEST['paged']
             : 1;
     }
+
+    public function views()
+    {
+        if (!method_exists($this, 'get_views')) {
+            return;
+        }
+
+        $views = $this->get_views();
+
+        if (empty($views)) {
+            return;
+        }
+
+        echo implode('', $views);
+    }
+
+    public function display()
+    {
+        // Intentionally left blank for tests.
+    }
 }


### PR DESCRIPTION
## Summary
- add HTTP status and recheck views to the broken links admin list table
- update the list table query to honour the new filters and centralise the recheck threshold helpers
- expand the dashboard page test suite and WP_List_Table stub to cover the new filters

## Testing
- vendor/bin/phpunit tests/BlcDashboardLinksPageTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dd2ec400b8832e976fb59942651374