### PR TITLE
Add ignore and recheck controls to broken link management

### DIFF
--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -290,6 +290,18 @@ class BLC_Links_List_Table extends WP_List_Table {
             wp_create_nonce('blc_unlink_nonce'),
             esc_html__('Dissocier', 'liens-morts-detector-jlg')
         );
+        $actions['ignore'] = sprintf(
+            '<a href="#" class="blc-ignore-link" %s data-nonce="%s">%s</a>',
+            $data_attributes,
+            wp_create_nonce('blc_ignore_link_nonce'),
+            esc_html__('Ignorer', 'liens-morts-detector-jlg')
+        );
+        $actions['recheck'] = sprintf(
+            '<a href="#" class="blc-recheck-link" %s data-nonce="%s">%s</a>',
+            $data_attributes,
+            wp_create_nonce('blc_recheck_link_nonce'),
+            esc_html__('Reprogrammer', 'liens-morts-detector-jlg')
+        );
         return $actions;
     }
 


### PR DESCRIPTION
## Summary
- add ignore and recheck actions to the broken links list table with localized labels for the admin UI
- implement AJAX handlers, storage helpers, and scanner updates to persist ignored URLs and queue targeted rechecks
- extend admin scripts and automated tests to cover the new workflows and user feedback

## Testing
- vendor/bin/phpunit tests/BlcAjaxCallbacksTest.php
- npm test -- blc-admin-scripts

------
https://chatgpt.com/codex/tasks/task_e_68dd2ec7a824832e8cc13eff05fa2132