### PR TITLE
Add bulk actions to broken link and image tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Liens Morts Detector est une extension WordPress qui détecte les liens et image
 ## Fonctionnalités
 - Vérification automatique des liens `<a>` grâce à WP‑Cron, et déclenchement manuel des images `<img>` (traitées ensuite en arrière-plan)
 - Planification quotidienne, hebdomadaire ou mensuelle  
-- Tableau de bord listant les liens et images cassés avec statistiques  
-- Actions rapides pour modifier une URL ou retirer un lien directement depuis la liste  
+- Tableau de bord listant les liens et images cassés avec statistiques
+- Actions groupées pour relancer une vérification ou purger plusieurs entrées en une seule fois
+- Actions rapides pour modifier une URL ou retirer un lien directement depuis la liste
 - Options avancées : exclusion de domaines, plages horaires de repos, mode debug
 
 ## Installation
@@ -17,6 +18,7 @@ Liens Morts Detector est une extension WordPress qui détecte les liens et image
 ## Utilisation
 - Les liens sont vérifiés automatiquement selon la fréquence choisie, tandis que les images nécessitent de lancer un scan manuel depuis le rapport (le traitement se poursuit ensuite en arrière-plan).
 - Les liens ou images détectés comme cassés apparaissent dans une table permettant la modification rapide de l’URL ou la suppression du lien.
+- Des actions groupées (relancer une vérification ou supprimer) sont disponibles au-dessus des tableaux pour traiter plusieurs éléments simultanément.
 - Des réglages avancés permettent d’exclure certains domaines, de limiter l’analyse à des plages horaires et d’activer un mode debug pour le suivi.
 
 ## Hooks disponibles

--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -16,6 +16,10 @@ if (!class_exists('WP_List_Table')) {
  */
 class BLC_Links_List_Table extends WP_List_Table {
 
+    private const CHECKBOX_FIELD_NAME = 'blc_link_ids';
+    private const BULK_NONCE_ACTION = 'blc_links_bulk_action';
+    private const BULK_NONCE_FIELD = 'blc_links_bulk_action_nonce';
+
     private $site_url;
 
     private $internal_url_condition_cache = null;
@@ -173,6 +177,7 @@ class BLC_Links_List_Table extends WP_List_Table {
      */
     public function get_columns() {
         return [
+            'cb'           => '<input type="checkbox" />',
             'url'          => __('URL Cassée', 'liens-morts-detector-jlg'),
             'anchor_text'  => __('Texte du lien', 'liens-morts-detector-jlg'),
             'http_status'  => __('Statut HTTP', 'liens-morts-detector-jlg'),
@@ -180,6 +185,135 @@ class BLC_Links_List_Table extends WP_List_Table {
             'post_title'   => __('Trouvé dans l\'article/page', 'liens-morts-detector-jlg'),
             'actions'      => __('Actions', 'liens-morts-detector-jlg')
         ];
+    }
+
+    /**
+     * Renders the checkbox column used for bulk actions.
+     */
+    protected function column_cb($item) {
+        $id = isset($item['id']) ? absint($item['id']) : 0;
+
+        if ($id <= 0) {
+            return '';
+        }
+
+        return sprintf(
+            '<input type="checkbox" name="%1$s[]" value="%2$d" />',
+            esc_attr($this->get_checkbox_field_name()),
+            $id
+        );
+    }
+
+    /**
+     * Returns the checkbox field name used in bulk actions.
+     */
+    public function get_checkbox_field_name() {
+        return self::CHECKBOX_FIELD_NAME;
+    }
+
+    /**
+     * Returns the nonce field name for bulk actions.
+     */
+    public function get_bulk_action_nonce_field_name() {
+        return self::BULK_NONCE_FIELD;
+    }
+
+    /**
+     * Returns the nonce action identifier for bulk actions.
+     */
+    public function get_bulk_action_nonce_action() {
+        return self::BULK_NONCE_ACTION;
+    }
+
+    /**
+     * Declares available bulk actions.
+     */
+    public function get_bulk_actions() {
+        return [
+            'blc_mark_for_recheck' => __('Planifier une nouvelle vérification', 'liens-morts-detector-jlg'),
+            'blc_delete_entries'   => __('Supprimer de la liste', 'liens-morts-detector-jlg'),
+        ];
+    }
+
+    /**
+     * Processes the selected bulk action and returns the outcome.
+     *
+     * @return array{processed:bool,action:string,count:int,ids:array,error:string}
+     */
+    public function process_bulk_action() {
+        $result = [
+            'processed' => false,
+            'action'    => '',
+            'count'     => 0,
+            'ids'       => [],
+            'error'     => '',
+        ];
+
+        if (empty($_POST)) {
+            return $result;
+        }
+
+        $action = $this->get_current_bulk_action();
+        if ($action === '') {
+            return $result;
+        }
+
+        $result['action'] = $action;
+
+        $ids = $this->get_requested_item_ids();
+        $result['ids'] = $ids;
+
+        if (empty($ids)) {
+            $result['error'] = 'no_ids';
+            return $result;
+        }
+
+        if (!$this->verify_bulk_action_nonce()) {
+            $result['error'] = 'invalid_nonce';
+            return $result;
+        }
+
+        global $wpdb;
+
+        if (!is_object($wpdb) || !method_exists($wpdb, 'prepare') || !method_exists($wpdb, 'query')) {
+            $result['error'] = 'missing_db';
+            return $result;
+        }
+
+        $table_name   = $wpdb->prefix . 'blc_broken_links';
+        $placeholders = implode(',', array_fill(0, count($ids), '%d'));
+        $query        = '';
+        $params       = [];
+
+        if ($action === 'blc_mark_for_recheck') {
+            $sentinel = $this->get_unchecked_sentinel_value();
+            $params   = array_merge([$sentinel, 'link'], $ids);
+            $query    = $wpdb->prepare(
+                "UPDATE $table_name SET last_checked_at = %s WHERE type = %s AND id IN ($placeholders)",
+                $params
+            );
+        } elseif ($action === 'blc_delete_entries') {
+            $params = array_merge(['link'], $ids);
+            $query  = $wpdb->prepare(
+                "DELETE FROM $table_name WHERE type = %s AND id IN ($placeholders)",
+                $params
+            );
+        } else {
+            $result['error'] = 'unknown_action';
+            return $result;
+        }
+
+        $query_result = $wpdb->query($query);
+
+        if ($query_result === false) {
+            $result['error'] = 'db_error';
+            return $result;
+        }
+
+        $result['processed'] = true;
+        $result['count']     = (int) $query_result;
+
+        return $result;
     }
 
     /**
@@ -504,6 +638,76 @@ class BLC_Links_List_Table extends WP_List_Table {
         }
 
         return trim($date_format . ' ' . $time_format);
+    }
+
+    private function get_requested_item_ids() {
+        $field = $this->get_checkbox_field_name();
+
+        if (!isset($_POST[$field])) {
+            return [];
+        }
+
+        $raw = wp_unslash($_POST[$field]);
+
+        if (!is_array($raw)) {
+            $raw = [$raw];
+        }
+
+        $ids = [];
+
+        foreach ($raw as $value) {
+            if (!is_scalar($value)) {
+                continue;
+            }
+
+            $id = absint($value);
+
+            if ($id > 0) {
+                $ids[$id] = $id;
+            }
+        }
+
+        return array_values($ids);
+    }
+
+    private function verify_bulk_action_nonce() {
+        $field = $this->get_bulk_action_nonce_field_name();
+
+        if (!isset($_POST[$field])) {
+            return false;
+        }
+
+        $nonce = $_POST[$field];
+
+        if (is_array($nonce)) {
+            return false;
+        }
+
+        $nonce = wp_unslash($nonce);
+
+        if (!function_exists('wp_verify_nonce')) {
+            return true;
+        }
+
+        return (bool) wp_verify_nonce($nonce, $this->get_bulk_action_nonce_action());
+    }
+
+    private function get_current_bulk_action() {
+        $candidates = ['action', 'action2'];
+
+        foreach ($candidates as $candidate) {
+            if (!isset($_POST[$candidate])) {
+                continue;
+            }
+
+            $raw = sanitize_text_field(wp_unslash($_POST[$candidate]));
+
+            if ($raw !== '' && $raw !== '-1') {
+                return $raw;
+            }
+        }
+
+        return '';
     }
 
     private function get_search_term() {


### PR DESCRIPTION
## Summary
- add checkbox columns, bulk action declarations, and request handling helpers to the broken links list table so actions like recheck and delete can be applied in bulk.【F:liens-morts-detector-jlg/includes/class-blc-links-list-table.php†L19-L317】
- mirror the bulk action support for broken images, including checkbox rendering, nonce helpers, and selecting IDs in queries.【F:liens-morts-detector-jlg/includes/class-blc-images-list-table.php†L18-L455】
- surface bulk action notices and nonce fields on the dashboard pages while wiring image and link forms to the new list-table APIs.【F:liens-morts-detector-jlg/includes/blc-admin-pages.php†L85-L455】
- extend the admin list table test suite with cron stubs, bulk action assertions, and dashboard POST coverage alongside documenting the feature in the README.【F:tests/AdminListTablesTest.php†L1-L641】【F:README.md†L5-L20】

## Testing
- `vendor/bin/phpunit tests`

------
https://chatgpt.com/codex/tasks/task_e_68dd42654aa0832e8aa24b0d9e396d64