### PR TITLE
Support remote CDN images in scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ Liens Morts Detector est une extension WordPress qui détecte les liens et image
 
 ## Fonctionnalités
 - Vérification automatique des liens `<a>` grâce à WP‑Cron, et déclenchement manuel des images `<img>` (traitées ensuite en arrière-plan)
-- Planification quotidienne, hebdomadaire ou mensuelle  
-- Tableau de bord listant les liens et images cassés avec statistiques  
-- Actions rapides pour modifier une URL ou retirer un lien directement depuis la liste  
+- Planification quotidienne, hebdomadaire ou mensuelle
+- Tableau de bord listant les liens et images cassés avec statistiques
+- Actions rapides pour modifier une URL ou retirer un lien directement depuis la liste
 - Options avancées : exclusion de domaines, plages horaires de repos, mode debug
+- Option dédiée pour analyser les images servies depuis un CDN ou un domaine externe sécurisé
 
 ## Installation
 1. Copier le dossier `liens-morts-detector-jlg` dans `wp-content/plugins/`.
@@ -18,6 +19,7 @@ Liens Morts Detector est une extension WordPress qui détecte les liens et image
 - Les liens sont vérifiés automatiquement selon la fréquence choisie, tandis que les images nécessitent de lancer un scan manuel depuis le rapport (le traitement se poursuit ensuite en arrière-plan).
 - Les liens ou images détectés comme cassés apparaissent dans une table permettant la modification rapide de l’URL ou la suppression du lien.
 - Des réglages avancés permettent d’exclure certains domaines, de limiter l’analyse à des plages horaires et d’activer un mode debug pour le suivi.
+- L’analyse des images distantes (CDN, sous-domaines médias) peut être activée dans les réglages. Cette vérification reste basée sur les fichiers présents dans `wp-content/uploads` et peut rallonger la durée du scan ou consommer davantage de quotas côté CDN.
 
 ## Hooks disponibles
 ### `blc_max_load_threshold`

--- a/tests/AdminListTablesTest.php
+++ b/tests/AdminListTablesTest.php
@@ -428,7 +428,7 @@ class AdminListTablesTest extends TestCase
 
         $this->assertCount(20, $table->items);
         $this->assertSame($expected_items, $table->items);
-        $this->assertStringContainsString("WHERE type = 'image'", $wpdb->last_get_results_query);
+        $this->assertStringContainsString("WHERE type IN ('image','remote-image')", $wpdb->last_get_results_query);
         $this->assertStringContainsString('LIMIT 20', $wpdb->last_get_results_query);
         $this->assertStringContainsString('OFFSET 0', $wpdb->last_get_results_query);
     }


### PR DESCRIPTION
## Summary
- add a settings checkbox to enable remote/CDN image analysis and document the new option
- extend the image scanner and dataset helpers to handle safe remote hosts and store dedicated `remote-image` rows
- update admin queries, list tables, and PHPUnit coverage to account for remote images with option-specific tests

## Testing
- `vendor/bin/phpunit tests`


------
https://chatgpt.com/codex/tasks/task_e_68dd4267a7b8832e9b1fa3a444a82453