### PR TITLE
Handle empty link list state and mark view counts dirty

### DIFF
--- a/liens-morts-detector-jlg/assets/js/__tests__/blc-admin-scripts.test.js
+++ b/liens-morts-detector-jlg/assets/js/__tests__/blc-admin-scripts.test.js
@@ -211,7 +211,13 @@ describe('blc-admin-scripts modal interactions', () => {
     ajax.triggerSuccess({ success: true });
 
     expect(modal.hasClass('is-open')).toBe(false);
-    expect($('#the-list tr').length).toBe(0);
+    const rows = $('#the-list tr');
+    expect(rows.length).toBe(1);
+
+    const noItemsRow = rows.filter('.no-items');
+    expect(noItemsRow.length).toBe(1);
+    expect(noItemsRow.find('td').attr('colspan')).toBe('1');
+    expect(noItemsRow.text()).toBe('Aucun élément à afficher.');
     expect(document.body.classList.contains('blc-modal-open')).toBe(false);
   });
 


### PR DESCRIPTION
## Summary
- add a localized fallback message and inject an empty state row when the list becomes empty after an action
- mark link view counters as dirty from the AJAX callbacks so PHP can refresh counts on the next load and emit a list update event
- update the Jest suite to cover the new empty state behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dd69a0b940832e80ff8781f699895d