### PR TITLE
Add post type filter to broken links list

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -225,8 +225,37 @@ function blc_dashboard_links_page() {
         <?php if ($broken_links_count === 0): ?>
              <p><?php esc_html_e('✅ Aucun lien mort trouvé. Bravo !', 'liens-morts-detector-jlg'); ?></p>
         <?php else: ?>
-            <form method="post">
-                <?php $list_table->views(); $list_table->display(); ?>
+            <form method="get">
+                <?php
+                $current_get_params = [];
+                if (!empty($_GET) && is_array($_GET)) {
+                    $current_get_params = $_GET;
+                }
+
+                foreach ($current_get_params as $key => $value) {
+                    if (in_array($key, ['s', 'post_type', 'paged'], true)) {
+                        continue;
+                    }
+
+                    if (is_scalar($value)) {
+                        printf(
+                            '<input type="hidden" name="%1$s" value="%2$s" />',
+                            esc_attr($key),
+                            esc_attr((string) $value)
+                        );
+                    }
+                }
+
+                if (isset($_REQUEST['page']) && (!isset($current_get_params['page']) || !is_scalar($current_get_params['page']))) {
+                    printf(
+                        '<input type="hidden" name="page" value="%s" />',
+                        esc_attr((string) $_REQUEST['page'])
+                    );
+                }
+
+                $list_table->views();
+                $list_table->display();
+                ?>
             </form>
         <?php endif; ?>
     </div>

--- a/tests/BlcDashboardLinksPageTest.php
+++ b/tests/BlcDashboardLinksPageTest.php
@@ -3,6 +3,15 @@
 namespace {
     require_once __DIR__ . '/translation-stubs.php';
     require_once __DIR__ . '/stubs/cron-stubs.php';
+
+    if (!function_exists('sanitize_key')) {
+        function sanitize_key($key)
+        {
+            $key = strtolower((string) $key);
+
+            return preg_replace('/[^a-z0-9_\-]/', '', $key);
+        }
+    }
 }
 
 namespace Tests {
@@ -170,6 +179,17 @@ class BlcDashboardLinksPageTest extends TestCase
         Functions\when('sanitize_text_field')->alias(static fn($value) => is_scalar($value) ? (string) $value : '');
         Functions\when('number_format_i18n')->alias(static function ($number, $decimals = 0) {
             return number_format((float) $number, (int) $decimals);
+        });
+        Functions\when('get_post_types')->alias(static function ($args = [], $output = 'names') {
+            return ['post', 'page'];
+        });
+        Functions\when('get_post_type_object')->alias(static function ($post_type) {
+            return (object) [
+                'labels' => (object) [
+                    'singular_name' => ucfirst((string) $post_type),
+                ],
+                'label' => ucfirst((string) $post_type),
+            ];
         });
         Functions\when('current_time')->alias(static function ($type, $gmt = 0) {
             if ($type === 'timestamp') {


### PR DESCRIPTION
## Summary
- add a post type dropdown filter to the broken links table UI and preserve the current filters when submitting the form
- constrain the list table queries by the selected post type when the filter is applied
- expand the PHPUnit coverage to exercise the new filter behaviour and required stubs

## Testing
- ./vendor/bin/phpunit tests/AdminListTablesTest.php
- ./vendor/bin/phpunit tests/BlcDashboardLinksPageTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dd69ae6528832e8c298a659dbf8579