### PR TITLE
Add ignore workflow for broken links in admin list

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-activation.php
+++ b/liens-morts-detector-jlg/includes/blc-activation.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('BLC_DB_VERSION')) {
-    define('BLC_DB_VERSION', '1.8.0');
+    define('BLC_DB_VERSION', '1.9.0');
 }
 
 if (!defined('BLC_TEXT_FIELD_LENGTH')) {
@@ -70,6 +70,11 @@ function blc_maybe_upgrade_database() {
     if (!$installed_version || version_compare($installed_version, '1.8.0', '<')) {
         blc_maybe_add_column($table_name, 'http_status', 'smallint(6) NULL');
         blc_maybe_add_column($table_name, 'last_checked_at', 'datetime NULL DEFAULT NULL');
+    }
+
+    if (!$installed_version || version_compare($installed_version, '1.9.0', '<')) {
+        blc_maybe_add_column($table_name, 'ignored_at', 'datetime NULL DEFAULT NULL');
+        blc_maybe_add_index($table_name, 'ignored_at', 'ignored_at');
     }
 
     update_option('blc_plugin_db_version', BLC_DB_VERSION);
@@ -342,12 +347,14 @@ function blc_activate_site() {
         is_internal tinyint(1) NOT NULL DEFAULT 0,
         http_status smallint(6) NULL,
         last_checked_at datetime NULL DEFAULT NULL,
+        ignored_at datetime NULL DEFAULT NULL,
         PRIMARY KEY  (id),
         KEY type (type),
         KEY post_id (post_id),
         KEY url_prefix (url(191)),
         KEY url_host (url_host),
-        KEY is_internal (is_internal)
+        KEY is_internal (is_internal),
+        KEY ignored_at (ignored_at)
     ) $charset_collate;";
 
     require_once ABSPATH . 'wp-admin/includes/upgrade.php';

--- a/liens-morts-detector-jlg/includes/blc-utils.php
+++ b/liens-morts-detector-jlg/includes/blc-utils.php
@@ -213,7 +213,7 @@ function blc_resolve_link_row($post_id, $row_id, $occurrence_value = null) {
 
     $row = $wpdb->get_row(
         $wpdb->prepare(
-            "SELECT id, post_id, url, anchor, post_title, occurrence_index FROM $table_name WHERE id = %d AND type = %s",
+            "SELECT id, post_id, url, anchor, post_title, occurrence_index, ignored_at FROM $table_name WHERE id = %d AND type = %s",
             $row_id,
             'link'
         ),
@@ -757,7 +757,7 @@ function blc_get_dataset_storage_footprint_bytes($type) {
             $wpdb->prepare(
                 "SELECT SUM(COALESCE(LENGTH(url), 0) + COALESCE(LENGTH(anchor), 0) + COALESCE(LENGTH(post_title), 0))
                  FROM $table_name
-                 WHERE type = %s",
+                 WHERE type = %s AND ignored_at IS NULL",
                 reset($row_types)
             )
         );
@@ -766,7 +766,7 @@ function blc_get_dataset_storage_footprint_bytes($type) {
         $query = $wpdb->prepare(
             "SELECT SUM(COALESCE(LENGTH(url), 0) + COALESCE(LENGTH(anchor), 0) + COALESCE(LENGTH(post_title), 0))
              FROM $table_name
-             WHERE type IN ($placeholders)",
+             WHERE type IN ($placeholders) AND ignored_at IS NULL",
             $row_types
         );
         $size = (int) $wpdb->get_var($query);


### PR DESCRIPTION
## Summary
- add an `ignored_at` column and migration, and expose an "Ignorés" filter in the links table
- implement the `wp_ajax_blc_ignore_link` endpoint with new row actions for ignoring or restoring links
- update the admin scripts to drive the ignore modal flow and extend the automated tests accordingly

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68dd69a8ce30832e8d22d490a686214d