### PR TITLE
Add ignore workflow to broken link list

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-activation.php
+++ b/liens-morts-detector-jlg/includes/blc-activation.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('BLC_DB_VERSION')) {
-    define('BLC_DB_VERSION', '1.8.0');
+    define('BLC_DB_VERSION', '1.9.0');
 }
 
 if (!defined('BLC_TEXT_FIELD_LENGTH')) {
@@ -70,6 +70,11 @@ function blc_maybe_upgrade_database() {
     if (!$installed_version || version_compare($installed_version, '1.8.0', '<')) {
         blc_maybe_add_column($table_name, 'http_status', 'smallint(6) NULL');
         blc_maybe_add_column($table_name, 'last_checked_at', 'datetime NULL DEFAULT NULL');
+    }
+
+    if (!$installed_version || version_compare($installed_version, '1.9.0', '<')) {
+        blc_maybe_add_column($table_name, 'ignored_at', 'datetime NULL DEFAULT NULL');
+        blc_maybe_add_index($table_name, 'ignored_at', 'ignored_at');
     }
 
     update_option('blc_plugin_db_version', BLC_DB_VERSION);
@@ -342,12 +347,14 @@ function blc_activate_site() {
         is_internal tinyint(1) NOT NULL DEFAULT 0,
         http_status smallint(6) NULL,
         last_checked_at datetime NULL DEFAULT NULL,
+        ignored_at datetime NULL DEFAULT NULL,
         PRIMARY KEY  (id),
         KEY type (type),
         KEY post_id (post_id),
         KEY url_prefix (url(191)),
         KEY url_host (url_host),
-        KEY is_internal (is_internal)
+        KEY is_internal (is_internal),
+        KEY ignored_at (ignored_at)
     ) $charset_collate;";
 
     require_once ABSPATH . 'wp-admin/includes/upgrade.php';

--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -163,7 +163,7 @@ function blc_dashboard_links_page() {
     $table_name = $wpdb->prefix . 'blc_broken_links';
     $broken_links_count = (int) $wpdb->get_var(
         $wpdb->prepare(
-            "SELECT COUNT(*) FROM $table_name WHERE type = %s",
+            "SELECT COUNT(*) FROM $table_name WHERE type = %s AND ignored_at IS NULL",
             'link'
         )
     );

--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -134,17 +134,19 @@ class BLC_Links_List_Table extends WP_List_Table {
 
         $counts_query = $wpdb->prepare(
             "SELECT
-                COUNT(*) AS total,
+                SUM(CASE WHEN ignored_at IS NULL THEN 1 ELSE 0 END) AS active_count,
+                SUM(CASE WHEN ignored_at IS NOT NULL THEN 1 ELSE 0 END) AS ignored_count,
                 SUM(
                     CASE
+                        WHEN ignored_at IS NOT NULL THEN 0
                         WHEN is_internal IS NOT NULL THEN is_internal
                         ELSE $legacy_case
                     END
                 ) AS internal_count,
-                SUM(CASE WHEN http_status IN (404, 410) THEN 1 ELSE 0 END) AS not_found_count,
-                SUM(CASE WHEN http_status BETWEEN 500 AND 599 THEN 1 ELSE 0 END) AS server_error_count,
-                SUM(CASE WHEN http_status BETWEEN 300 AND 399 THEN 1 ELSE 0 END) AS redirect_count,
-                SUM(CASE WHEN $needs_recheck_clause THEN 1 ELSE 0 END) AS needs_recheck_count
+                SUM(CASE WHEN ignored_at IS NULL AND http_status IN (404, 410) THEN 1 ELSE 0 END) AS not_found_count,
+                SUM(CASE WHEN ignored_at IS NULL AND http_status BETWEEN 500 AND 599 THEN 1 ELSE 0 END) AS server_error_count,
+                SUM(CASE WHEN ignored_at IS NULL AND http_status BETWEEN 300 AND 399 THEN 1 ELSE 0 END) AS redirect_count,
+                SUM(CASE WHEN ignored_at IS NULL AND $needs_recheck_clause THEN 1 ELSE 0 END) AS needs_recheck_count
              FROM $table_name
              WHERE type = %s",
             array_merge($legacy_params, $needs_recheck_params, ['link'])
@@ -152,14 +154,16 @@ class BLC_Links_List_Table extends WP_List_Table {
 
         $counts = $wpdb->get_row($counts_query, ARRAY_A);
 
-        $total_count        = isset($counts['total']) ? (int) $counts['total'] : 0;
+        $active_count       = isset($counts['active_count']) ? (int) $counts['active_count'] : 0;
+        $ignored_count      = isset($counts['ignored_count']) ? (int) $counts['ignored_count'] : 0;
         $internal_count     = isset($counts['internal_count']) ? (int) $counts['internal_count'] : 0;
-        $external_count     = max(0, $total_count - $internal_count);
+        $external_count     = max(0, $active_count - $internal_count);
         $not_found_count    = isset($counts['not_found_count']) ? (int) $counts['not_found_count'] : 0;
         $server_error_count = isset($counts['server_error_count']) ? (int) $counts['server_error_count'] : 0;
         $redirect_count     = isset($counts['redirect_count']) ? (int) $counts['redirect_count'] : 0;
         $needs_recheck_count = isset($counts['needs_recheck_count']) ? (int) $counts['needs_recheck_count'] : 0;
 
+        $total_count = $active_count;
         $all_class = ($current === 'all' ? 'current' : '');
         $views['all'] = sprintf(
             "<a href='%s' class='%s'>%s <span class='count'>(%d)</span></a>",
@@ -221,6 +225,15 @@ class BLC_Links_List_Table extends WP_List_Table {
             esc_attr($needs_recheck_class),
             esc_html__('À revérifier', 'liens-morts-detector-jlg'),
             $needs_recheck_count
+        );
+
+        $ignored_class = ($current === 'ignored' ? 'current' : '');
+        $views['ignored'] = sprintf(
+            "<a href='%s' class='%s'>%s <span class='count'>(%d)</span></a>",
+            esc_url(add_query_arg('link_type', 'ignored')),
+            esc_attr($ignored_class),
+            esc_html__('Ignorés', 'liens-morts-detector-jlg'),
+            $ignored_count
         );
 
         return $views;
@@ -388,6 +401,28 @@ class BLC_Links_List_Table extends WP_List_Table {
             wp_create_nonce('blc_edit_link_nonce'),
             esc_html__('Modifier', 'liens-morts-detector-jlg')
         );
+
+        $ignored_raw = $item['ignored_at'] ?? null;
+        $is_ignored = false;
+        if (is_string($ignored_raw)) {
+            $normalized_ignored = trim($ignored_raw);
+            $is_ignored = ($normalized_ignored !== '' && $normalized_ignored !== '0000-00-00 00:00:00');
+        } elseif ($ignored_raw !== null) {
+            $is_ignored = true;
+        }
+
+        $ignore_mode = $is_ignored ? 'restore' : 'ignore';
+        $ignore_label = $is_ignored
+            ? esc_html__('Ne plus ignorer', 'liens-morts-detector-jlg')
+            : esc_html__('Ignorer', 'liens-morts-detector-jlg');
+
+        $actions['ignore'] = sprintf(
+            '<a href="#" class="blc-ignore" %s data-ignore-mode="%s" data-nonce="%s">%s</a>',
+            $data_attributes,
+            esc_attr($ignore_mode),
+            wp_create_nonce('blc_ignore_link_nonce'),
+            $ignore_label
+        );
         $actions['unlink'] = sprintf(
             '<a href="#" class="blc-unlink" %s data-nonce="%s" style="color:#a00;">%s</a>',
             $data_attributes,
@@ -440,6 +475,8 @@ class BLC_Links_List_Table extends WP_List_Table {
         $external_sql       = $internal_condition['not_sql'];
         $external_params    = $internal_condition['not_params'];
 
+        $is_ignored_view = ($current_view === 'ignored');
+
         $where  = ['type = %s'];
         $params = ['link'];
 
@@ -452,6 +489,12 @@ class BLC_Links_List_Table extends WP_List_Table {
         if ($selected_post_type !== '' && in_array($selected_post_type, $available_post_types, true)) {
             $where[] = 'post_type = %s';
             $params[] = $selected_post_type;
+        }
+
+        if ($is_ignored_view) {
+            $where[] = 'ignored_at IS NOT NULL';
+        } else {
+            $where[] = 'ignored_at IS NULL';
         }
 
         if ($current_view === 'internal') {
@@ -486,11 +529,13 @@ class BLC_Links_List_Table extends WP_List_Table {
 
         $offset = ($current_page - 1) * $per_page;
 
+        $order_by = $is_ignored_view ? 'ignored_at DESC, id DESC' : 'id DESC';
+
         $data_query = $wpdb->prepare(
-            "SELECT id, occurrence_index, url, anchor, post_id, post_title, http_status, last_checked_at
+            "SELECT id, occurrence_index, url, anchor, post_id, post_title, http_status, last_checked_at, ignored_at
              FROM $table_name
              WHERE $where_clause
-             ORDER BY id DESC
+             ORDER BY $order_by
              LIMIT %d OFFSET %d",
             array_merge($params, [$per_page, $offset])
         );


### PR DESCRIPTION
## Summary
- add an `ignored_at` column and migration so ignored rows can be tracked separately
- expose an "Ignored" view and ignore/unignore quick action with the associated AJAX handler and modal flow
- update dataset footprint helpers and dashboard stats to exclude ignored rows from active counts

## Testing
- `php -l liens-morts-detector-jlg/includes/blc-activation.php`
- `php -l liens-morts-detector-jlg/includes/blc-admin-pages.php`
- `php -l liens-morts-detector-jlg/includes/blc-utils.php`
- `php -l liens-morts-detector-jlg/includes/class-blc-links-list-table.php`
- `php -l liens-morts-detector-jlg/liens-morts-detector-jlg.php`


------
https://chatgpt.com/codex/tasks/task_e_68dd7efe89b0832e967509ef35c46c86