### PR TITLE
Add post type filter to broken links list table

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -225,7 +225,8 @@ function blc_dashboard_links_page() {
         <?php if ($broken_links_count === 0): ?>
              <p><?php esc_html_e('✅ Aucun lien mort trouvé. Bravo !', 'liens-morts-detector-jlg'); ?></p>
         <?php else: ?>
-            <form method="get">
+            <form method="get" class="blc-links-filter-form" aria-labelledby="blc-links-filter-heading">
+                <h2 id="blc-links-filter-heading" class="screen-reader-text"><?php esc_html_e('Filtres de la liste des liens cassés', 'liens-morts-detector-jlg'); ?></h2>
                 <?php
                 $current_get_params = [];
                 if (!empty($_GET) && is_array($_GET)) {

--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -57,27 +57,12 @@ class BLC_Links_List_Table extends WP_List_Table {
             return;
         }
 
-        $available_post_types = [];
-        $post_types = function_exists('get_post_types') ? get_post_types(['public' => true]) : [];
-        if (is_array($post_types)) {
-            foreach ($post_types as $post_type) {
-                if (is_string($post_type) && $post_type !== '') {
-                    $available_post_types[] = $post_type;
-                }
-            }
-        }
-
-        $selected_post_type = '';
-        if (isset($_GET['post_type'])) {
-            $candidate = sanitize_key(wp_unslash($_GET['post_type']));
-            if ($candidate !== '') {
-                $selected_post_type = $candidate;
-            }
-        }
+        $available_post_types = $this->get_available_post_types();
+        $selected_post_type  = $this->get_selected_post_type();
 
         if (!empty($available_post_types)) {
             echo '<div class="alignleft actions">';
-            echo '<label class="screen-reader-text" for="blc-post-type-filter">' . esc_html__('Filtrer par type de contenu', 'liens-morts-detector-jlg') . '</label>';
+            echo '<label for="blc-post-type-filter" class="blc-filter__label">' . esc_html__('Filtrer par type de contenu', 'liens-morts-detector-jlg') . '</label>';
 
             $select  = '<select name="post_type" id="blc-post-type-filter" aria-label="' . esc_attr__('Filtrer par type de contenu', 'liens-morts-detector-jlg') . '">';
             $select .= '<option value="">' . esc_html__('Tous les types de contenu', 'liens-morts-detector-jlg') . '</option>';
@@ -407,23 +392,8 @@ class BLC_Links_List_Table extends WP_List_Table {
         $current_page = max(1, (int) $this->get_pagenum());
         $search_term  = $this->get_search_term();
 
-        $available_post_types = [];
-        $post_types = function_exists('get_post_types') ? get_post_types(['public' => true]) : [];
-        if (is_array($post_types)) {
-            foreach ($post_types as $post_type) {
-                if (is_string($post_type) && $post_type !== '') {
-                    $available_post_types[] = $post_type;
-                }
-            }
-        }
-
-        $selected_post_type = '';
-        if (isset($_GET['post_type'])) {
-            $candidate = sanitize_key(wp_unslash($_GET['post_type']));
-            if ($candidate !== '') {
-                $selected_post_type = $candidate;
-            }
-        }
+        $available_post_types = $this->get_available_post_types();
+        $selected_post_type  = $this->get_selected_post_type();
 
         if (is_array($data)) {
             $total_items = ($total_items_override !== null) ? (int) $total_items_override : count($data);
@@ -585,6 +555,48 @@ class BLC_Links_List_Table extends WP_List_Table {
         }
 
         return trim($date_format . ' ' . $time_format);
+    }
+
+    private function get_available_post_types() {
+        if (!function_exists('get_post_types')) {
+            return [];
+        }
+
+        $post_types = get_post_types(['public' => true]);
+        if (!is_array($post_types)) {
+            return [];
+        }
+
+        $available_post_types = [];
+
+        foreach ($post_types as $post_type) {
+            if (is_string($post_type) && $post_type !== '') {
+                $available_post_types[] = $post_type;
+            }
+        }
+
+        return array_values(array_unique($available_post_types));
+    }
+
+    private function get_selected_post_type() {
+        if (!isset($_GET['post_type'])) {
+            return '';
+        }
+
+        $raw_value = $_GET['post_type'];
+        if (!is_string($raw_value)) {
+            return '';
+        }
+
+        if (function_exists('wp_unslash')) {
+            $raw_value = wp_unslash($raw_value);
+        }
+
+        if (function_exists('sanitize_key')) {
+            $raw_value = sanitize_key($raw_value);
+        }
+
+        return $raw_value === '' ? '' : $raw_value;
     }
 
     private function get_search_term() {

--- a/tests/AdminListTablesTest.php
+++ b/tests/AdminListTablesTest.php
@@ -243,6 +243,28 @@ class AdminListTablesTest extends TestCase
         $this->assertStringContainsString("post_type = 'page'", $wpdb->last_get_results_query);
     }
 
+    public function test_links_extra_tablenav_displays_post_type_filter(): void
+    {
+        $_GET['post_type'] = 'page';
+
+        $table = new class() extends \BLC_Links_List_Table {
+            public function captureExtraTablenav($which)
+            {
+                ob_start();
+                parent::extra_tablenav($which);
+
+                return ob_get_clean();
+            }
+        };
+
+        $output = $table->captureExtraTablenav('top');
+
+        $this->assertStringContainsString('name="post_type"', $output);
+        $this->assertStringContainsString('id="blc-post-type-filter"', $output);
+        $this->assertStringContainsString('Filtrer par type de contenu', $output);
+        $this->assertStringContainsString('<option value="page" selected="selected">', $output);
+    }
+
     public function test_images_columns_display_status_and_timestamp(): void
     {
         $table = new class() extends \BLC_Images_List_Table {


### PR DESCRIPTION
## Summary
- add reusable helpers to supply the post type dropdown for the broken links list table and reuse them during query preparation
- expose an accessible label and heading for the post type filter on the dashboard page
- cover the new filter markup and query clause with list table tests

## Testing
- vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68dd7f008dec832e8a0501bd82e2c743