### PR TITLE
Handle empty image row types gracefully

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -333,23 +333,29 @@ function blc_dashboard_images_page() {
     global $wpdb;
     $table_name = $wpdb->prefix . 'blc_broken_links';
     $image_row_types = blc_get_dataset_row_types('image');
-    if (count($image_row_types) === 1) {
-        $broken_images_count = (int) $wpdb->get_var(
-            $wpdb->prepare(
-                "SELECT COUNT(*) FROM $table_name WHERE type = %s",
-                reset($image_row_types)
-            )
-        );
-    } else {
-        $placeholders = implode(',', array_fill(0, count($image_row_types), '%s'));
-        $query = $wpdb->prepare(
-            "SELECT COUNT(*) FROM $table_name WHERE type IN ($placeholders)",
-            $image_row_types
-        );
-        $broken_images_count = (int) $wpdb->get_var($query);
-    }
-    $option_size_bytes = blc_get_dataset_storage_footprint_bytes('image');
+    $broken_images_count = 0;
+    $option_size_bytes = 0;
     $last_image_check_time = get_option('blc_last_image_check_time', 0);
+
+    if ($image_row_types !== []) {
+        if (count($image_row_types) === 1) {
+            $broken_images_count = (int) $wpdb->get_var(
+                $wpdb->prepare(
+                    "SELECT COUNT(*) FROM $table_name WHERE type = %s",
+                    reset($image_row_types)
+                )
+            );
+        } else {
+            $placeholders = implode(',', array_fill(0, count($image_row_types), '%s'));
+            $query = $wpdb->prepare(
+                "SELECT COUNT(*) FROM $table_name WHERE type IN ($placeholders)",
+                $image_row_types
+            );
+            $broken_images_count = (int) $wpdb->get_var($query);
+        }
+
+        $option_size_bytes = blc_get_dataset_storage_footprint_bytes('image');
+    }
     $option_size_kb      = $option_size_bytes / 1024;
     $size_display        = ($option_size_kb < 1024)
         ? sprintf('%s %s', number_format_i18n($option_size_kb, 2), __('Ko', 'liens-morts-detector-jlg'))

--- a/liens-morts-detector-jlg/includes/class-blc-images-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-images-list-table.php
@@ -133,6 +133,13 @@ class BLC_Images_List_Table extends WP_List_Table {
         $table_name = $wpdb->prefix . 'blc_broken_links';
 
         $image_row_types = blc_get_dataset_row_types('image');
+        if ($image_row_types === []) {
+            $this->set_pagination_args(['total_items' => 0, 'per_page' => $per_page]);
+            $this->items = [];
+
+            return;
+        }
+
         if (count($image_row_types) === 1) {
             $total_items = (int) $wpdb->get_var(
                 $wpdb->prepare(


### PR DESCRIPTION
## Summary
- skip image dashboard database queries when the dataset row types filter returns an empty array and render zeroed counters
- short-circuit the images list table preparation when no row types are available to avoid SQL building
- cover the empty row types scenario in dashboard and list table tests by registering a filter that returns an empty array

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68dd91acd908832e86667154fa9b887b