### PR TITLE
Handle non-scalar page request parameters

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -247,7 +247,11 @@ function blc_dashboard_links_page() {
                     }
                 }
 
-                if (isset($_REQUEST['page']) && (!isset($current_get_params['page']) || !is_scalar($current_get_params['page']))) {
+                if (
+                    isset($_REQUEST['page'])
+                    && is_scalar($_REQUEST['page'])
+                    && (!isset($current_get_params['page']) || !is_scalar($current_get_params['page']))
+                ) {
                     printf(
                         '<input type="hidden" name="page" value="%s" />',
                         esc_attr((string) $_REQUEST['page'])

--- a/tests/BlcDashboardLinksPageTest.php
+++ b/tests/BlcDashboardLinksPageTest.php
@@ -341,6 +341,28 @@ class BlcDashboardLinksPageTest extends TestCase
         $this->assertStringContainsString("À revérifier <span class='count'>(2)</span>", $output);
     }
 
+    public function test_hidden_page_field_not_rendered_for_non_scalar_request(): void
+    {
+        $_REQUEST['page'] = ['foo'];
+
+        $errors = [];
+        set_error_handler(static function ($severity, $message) use (&$errors) {
+            $errors[] = $message;
+
+            return true;
+        });
+
+        ob_start();
+        blc_dashboard_links_page();
+        $output = (string) ob_get_clean();
+
+        restore_error_handler();
+        unset($_REQUEST['page']);
+
+        $this->assertSame([], $errors);
+        $this->assertStringNotContainsString('<input type="hidden" name="page"', $output);
+    }
+
     /**
      * @return array<string, array{0: string, 1: string}>
      */


### PR DESCRIPTION
## Summary
- guard the dashboard links page hidden field injection so non-scalar request values are ignored
- add a regression test ensuring array request values do not trigger PHP notices or render the hidden field

## Testing
- ./vendor/bin/phpunit --testdox tests

------
https://chatgpt.com/codex/tasks/task_e_68dd91a5e2f0832ebb4de8cb23fffae5