### PR TITLE
Fix post type filtering for broken links list

### DIFF
--- a/tests/AdminListTablesTest.php
+++ b/tests/AdminListTablesTest.php
@@ -239,8 +239,10 @@ class AdminListTablesTest extends TestCase
         $table->prepare_items();
 
         $this->assertSame($expected_items, $table->items);
-        $this->assertStringContainsString("post_type = 'page'", $wpdb->last_get_var_query);
-        $this->assertStringContainsString("post_type = 'page'", $wpdb->last_get_results_query);
+        $this->assertStringContainsString("posts.post_type = 'page'", $wpdb->last_get_var_query);
+        $this->assertStringContainsString("posts.post_type = 'page'", $wpdb->last_get_results_query);
+        $this->assertStringContainsString('LEFT JOIN wp_posts AS posts', $wpdb->last_get_var_query);
+        $this->assertStringContainsString('LEFT JOIN wp_posts AS posts', $wpdb->last_get_results_query);
     }
 
     public function test_links_extra_tablenav_displays_post_type_filter(): void
@@ -565,6 +567,7 @@ class AdminListTablesTest extends TestCase
 class DummyWpdb
 {
     public $prefix = 'wp_';
+    public $posts = 'wp_posts';
     public $get_var_return_values = [];
     public $results_to_return;
     public $last_get_var_query;


### PR DESCRIPTION
## Summary
- join the posts table when loading broken links so the post type filter uses a valid column
- include the post type in item and count queries to keep pagination in sync
- extend the dashboard and admin list table tests to cover the joined queries

## Testing
- ./vendor/bin/phpunit tests/BlcDashboardLinksPageTest.php
- ./vendor/bin/phpunit tests/AdminListTablesTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dda22844a0832e8577628f28467263