### PR TITLE
Add thumbnail previews to broken images admin table

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -63,6 +63,32 @@
     overflow-wrap: anywhere;
 }
 
+.wp-list-table td.column-image_details .blc-image-details {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+}
+
+.blc-image-preview {
+    flex: 0 0 auto;
+    max-width: 96px;
+}
+
+.blc-image-preview__img {
+    display: block;
+    width: 100%;
+    height: auto;
+    max-height: 96px;
+    border-radius: 4px;
+    object-fit: cover;
+    background-color: #f6f7f7;
+}
+
+.blc-image-details__content {
+    flex: 1 1 auto;
+    min-width: 0;
+}
+
 @media (max-width: 782px) {
     .wp-list-table {
         display: block;
@@ -137,6 +163,20 @@
 
     .wp-list-table td .row-actions span {
         display: inline-flex;
+    }
+
+    .wp-list-table td.column-image_details .blc-image-details {
+        flex-direction: column;
+        gap: 10px;
+    }
+
+    .blc-image-preview {
+        width: clamp(96px, 45vw, 140px);
+        max-width: 100%;
+    }
+
+    .blc-image-preview__img {
+        max-height: 160px;
     }
 }
 


### PR DESCRIPTION
## Summary
- render secure thumbnail previews in the broken images list by preferring attachment IDs and falling back to sanitized URLs
- style the new preview container for desktop and mobile displays in the admin table
- cover the thumbnail rendering with a dedicated unit test of the image column output

## Testing
- vendor/bin/phpunit tests/BlcDashboardImagesPageTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dda23534a0832eaea35f8728fba67a