### PR TITLE
Expand link scanner coverage to comments, metadata, and widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Liens Morts Detector est une extension WordPress qui détecte les liens et image
 
 ## Fonctionnalités
 - Vérification automatique des liens `<a>` grâce à WP‑Cron, et déclenchement manuel des images `<img>` (traitées ensuite en arrière-plan)
+- Analyse des liens issus des commentaires, des métadonnées personnalisées et des widgets texte WordPress
 - Planification quotidienne, hebdomadaire ou mensuelle
 - Tableau de bord listant les liens et images cassés avec statistiques
 - Actions rapides pour modifier une URL ou retirer un lien directement depuis la liste


### PR DESCRIPTION
## Summary
- add a reusable helper to parse anchor tags from arbitrary HTML snippets
- extend the link scan pipeline to ingest links from approved comments, post meta values, and text widgets
- cover the new sources with PHPUnit scenarios and document the expanded coverage

## Testing
- `vendor/bin/phpunit tests/BlcScannerTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68dda233a1c8832ebc8ca2c375cccfa0