### PR TITLE
Refactor link scan scheduling through dedicated controller classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,9 @@
 {
+    "autoload": {
+        "psr-4": {
+            "JLG\\BrokenLinks\\": "liens-morts-detector-jlg/includes/"
+        }
+    },
     "require-dev": {
         "phpunit/phpunit": "^9",
         "brain/monkey": "^2.6"

--- a/liens-morts-detector-jlg/includes/Scanner/LinkScanController.php
+++ b/liens-morts-detector-jlg/includes/Scanner/LinkScanController.php
@@ -1,0 +1,373 @@
+<?php
+
+namespace JLG\BrokenLinks\Scanner;
+
+use WP_Error;
+use WP_Query;
+
+class LinkScanController
+{
+    private \wpdb $wpdb;
+    private ScanQueue $scanQueue;
+    private bool $debugMode;
+    private int $restStartHour;
+    private int $restEndHour;
+    private int $batchDelay;
+    private int $lockTimeout;
+    private int $lastCheckTime;
+    private $acquireLock;
+    private $releaseLock;
+    private $scheduleEvent;
+    private $doAction;
+    private $errorLogger;
+    private $timeProvider;
+    private $currentFilter;
+
+    public function __construct(
+        \wpdb $wpdb,
+        ScanQueue $scanQueue,
+        array $options,
+        callable $acquireLock,
+        callable $releaseLock,
+        callable $scheduleEvent,
+        callable $doAction,
+        callable $errorLogger,
+        callable $timeProvider,
+        ?callable $currentFilter = null
+    ) {
+        $this->wpdb = $wpdb;
+        $this->scanQueue = $scanQueue;
+        $this->debugMode = (bool) ($options['debug_mode'] ?? false);
+        $this->restStartHour = (int) ($options['rest_start_hour'] ?? 0);
+        $this->restEndHour = (int) ($options['rest_end_hour'] ?? 0);
+        $this->batchDelay = (int) ($options['batch_delay'] ?? 0);
+        $this->lockTimeout = (int) ($options['lock_timeout'] ?? 0);
+        $this->lastCheckTime = (int) ($options['last_check_time'] ?? 0);
+        $this->acquireLock = $acquireLock;
+        $this->releaseLock = $releaseLock;
+        $this->scheduleEvent = $scheduleEvent;
+        $this->doAction = $doAction;
+        $this->errorLogger = $errorLogger;
+        $this->timeProvider = $timeProvider;
+        $this->currentFilter = $currentFilter;
+    }
+
+    /**
+     * @return array{lock_token: string, posts: array<int, \WP_Post>, query: WP_Query, is_full_scan: bool, bypass_rest_window: bool}|WP_Error|null
+     */
+    public function runBatch(int $batch, bool $isFullScan, bool $bypassRestWindow)
+    {
+        $currentHook = $this->getCurrentHook();
+        if (!$isFullScan && $currentHook === 'blc_check_links') {
+            $isFullScan = true;
+        }
+
+        if ($currentHook === 'blc_check_links') {
+            $bypassRestWindow = false;
+        }
+
+        $lockToken = (string) call_user_func($this->acquireLock, $this->lockTimeout);
+        if ($lockToken === '') {
+            if ($currentHook === 'blc_check_links') {
+                if ($this->debugMode) {
+                    $this->log('Analyse de liens déjà en cours, reprogrammation du lot.');
+                }
+
+                $retryDelay = max(60, $this->batchDelay);
+                $this->scheduleRetry(
+                    $retryDelay,
+                    $batch,
+                    $isFullScan,
+                    $bypassRestWindow,
+                    'lock_unavailable',
+                    sprintf('BLC: Failed to reschedule link batch #%d while waiting for lock.', $batch)
+                );
+                return null;
+            }
+
+            return new WP_Error(
+                'blc_link_scan_in_progress',
+                __('Une analyse des liens est déjà en cours. Veuillez réessayer plus tard.', 'liens-morts-detector-jlg')
+            );
+        }
+
+        $currentHour = (int) current_time('H');
+        if ($this->isInRestWindow($currentHour) && !$bypassRestWindow) {
+            if ($this->debugMode) {
+                $this->log('Scan arrêté : dans la plage horaire de repos.');
+            }
+
+            $this->scheduleRestWindow($batch, $isFullScan, $bypassRestWindow, $currentHour);
+            $this->releaseLock($lockToken);
+            return null;
+        }
+
+        if ($this->isServerLoadTooHigh($batch, $isFullScan, $bypassRestWindow)) {
+            $this->releaseLock($lockToken);
+            return null;
+        }
+
+        $batchData = $this->scanQueue->loadBatch($batch, $isFullScan, $this->lastCheckTime);
+
+        return [
+            'lock_token'           => $lockToken,
+            'posts'                => $batchData['posts'],
+            'query'                => $batchData['query'],
+            'is_full_scan'         => $isFullScan,
+            'bypass_rest_window'   => $bypassRestWindow,
+        ];
+    }
+
+    public function releaseLock(string $lockToken): void
+    {
+        if ($lockToken === '') {
+            return;
+        }
+
+        call_user_func($this->releaseLock, $lockToken);
+    }
+
+    public function scheduleNextBatchIfNeeded(
+        WP_Query $query,
+        int $currentBatch,
+        bool $isFullScan,
+        bool $bypassRestWindow
+    ): bool {
+        return $this->scanQueue->scheduleNextBatchIfNeeded($query, $currentBatch, $isFullScan, $bypassRestWindow);
+    }
+
+    public function scheduleRetry(
+        int $delaySeconds,
+        int $batch,
+        bool $isFullScan,
+        bool $bypassRestWindow,
+        string $reason,
+        ?string $failureMessage = null
+    ): bool {
+        if ($delaySeconds < 0) {
+            $delaySeconds = 0;
+        }
+
+        $timestamp = $this->now() + $delaySeconds;
+        $scheduled = call_user_func(
+            $this->scheduleEvent,
+            $timestamp,
+            'blc_check_batch',
+            [$batch, $isFullScan, $bypassRestWindow]
+        );
+
+        if (false === $scheduled) {
+            if ($failureMessage === null) {
+                $failureMessage = sprintf('BLC: Failed to schedule link batch #%d.', $batch);
+            }
+            $this->log($failureMessage);
+            call_user_func(
+                $this->doAction,
+                'blc_check_batch_schedule_failed',
+                $batch,
+                $isFullScan,
+                $bypassRestWindow,
+                $reason
+            );
+            return false;
+        }
+
+        return true;
+    }
+
+    public function getLastCheckTime(): int
+    {
+        return $this->lastCheckTime;
+    }
+
+    public function getBatchDelay(): int
+    {
+        return $this->batchDelay;
+    }
+
+    public function isDebugMode(): bool
+    {
+        return $this->debugMode;
+    }
+
+    private function isInRestWindow(int $currentHour): bool
+    {
+        if ($this->restStartHour <= $this->restEndHour) {
+            return $currentHour >= $this->restStartHour && $currentHour < $this->restEndHour;
+        }
+
+        return $currentHour >= $this->restStartHour || $currentHour < $this->restEndHour;
+    }
+
+    private function scheduleRestWindow(
+        int $batch,
+        bool $isFullScan,
+        bool $bypassRestWindow,
+        int $currentHour
+    ): void {
+        $currentTimestamp = $this->now();
+        $timezone = $this->resolveTimezone();
+        $currentDateTime = (new \DateTimeImmutable('@' . $currentTimestamp))->setTimezone($timezone);
+        $nextRun = $currentDateTime->setTime($this->restEndHour, 0, 0);
+
+        if ($this->restStartHour > $this->restEndHour) {
+            if ($currentHour >= $this->restStartHour) {
+                $nextRun = $nextRun->modify('+1 day');
+            } elseif ($nextRun <= $currentDateTime) {
+                $nextRun = $nextRun->modify('+1 day');
+            }
+        } elseif ($nextRun <= $currentDateTime) {
+            $nextRun = $nextRun->modify('+1 day');
+        }
+
+        $nextTimestamp = $nextRun->getTimestamp();
+        if ($nextTimestamp <= $currentTimestamp) {
+            $nextTimestamp = $currentTimestamp + 60;
+        }
+
+        $scheduled = call_user_func(
+            $this->scheduleEvent,
+            $nextTimestamp,
+            'blc_check_batch',
+            [$batch, $isFullScan, $bypassRestWindow]
+        );
+
+        if (false === $scheduled) {
+            $this->log(sprintf('BLC: Failed to schedule link batch #%d during rest window.', $batch));
+            call_user_func(
+                $this->doAction,
+                'blc_check_batch_schedule_failed',
+                $batch,
+                $isFullScan,
+                $bypassRestWindow,
+                'rest_window'
+            );
+        }
+    }
+
+    private function resolveTimezone(): \DateTimeZone
+    {
+        if (function_exists('wp_timezone')) {
+            $timezone = wp_timezone();
+            if ($timezone instanceof \DateTimeZone) {
+                return $timezone;
+            }
+        }
+
+        if (function_exists('wp_timezone_string')) {
+            $timezoneString = wp_timezone_string();
+            if (is_string($timezoneString) && $timezoneString !== '') {
+                try {
+                    return new \DateTimeZone($timezoneString);
+                } catch (\Exception $e) {
+                    // Fall back to offset handling below.
+                }
+            }
+        }
+
+        $offset = (float) get_option('gmt_offset', 0);
+        $offsetSeconds = (int) round($offset * 3600);
+        $timezoneName = timezone_name_from_abbr('', $offsetSeconds, 0);
+
+        if (is_string($timezoneName) && $timezoneName !== '') {
+            try {
+                return new \DateTimeZone($timezoneName);
+            } catch (\Exception $e) {
+                // Continue to manual offset formatting.
+            }
+        }
+
+        $sign = $offset >= 0 ? '+' : '-';
+        $absOffset = abs($offset);
+        $hours = (int) floor($absOffset);
+        $minutes = (int) round(($absOffset - $hours) * 60);
+
+        if ($minutes === 60) {
+            $hours += 1;
+            $minutes = 0;
+        }
+
+        $formattedOffset = sprintf('%s%02d:%02d', $sign, $hours, $minutes);
+
+        try {
+            return new \DateTimeZone($formattedOffset);
+        } catch (\Exception $e) {
+            return new \DateTimeZone('UTC');
+        }
+    }
+
+    private function isServerLoadTooHigh(int $batch, bool $isFullScan, bool $bypassRestWindow): bool
+    {
+        if (!function_exists('sys_getloadavg')) {
+            if ($this->debugMode) {
+                $this->log('Contrôle de charge ignoré : sys_getloadavg() n\'est pas disponible.');
+            }
+            return false;
+        }
+
+        $loadValues = sys_getloadavg();
+        if (!is_array($loadValues) || empty($loadValues)) {
+            if ($this->debugMode) {
+                $this->log('Contrôle de charge ignoré : sys_getloadavg() n\'a pas retourné de données valides.');
+            }
+            return false;
+        }
+
+        $currentLoad = reset($loadValues);
+        if (!is_numeric($currentLoad)) {
+            if ($this->debugMode) {
+                $this->log('Contrôle de charge ignoré : la première valeur retournée par sys_getloadavg() n\'est pas numérique.');
+            }
+            return false;
+        }
+
+        $currentLoad = (float) $currentLoad;
+        $maxLoadThreshold = (float) apply_filters('blc_max_load_threshold', 2.0);
+
+        if ($maxLoadThreshold > 0 && $currentLoad > $maxLoadThreshold) {
+            $retryDelay = (int) apply_filters('blc_load_retry_delay', 300);
+            if ($retryDelay < 0) {
+                $retryDelay = 0;
+            }
+
+            if ($this->debugMode) {
+                $this->log('Scan reporté : charge serveur trop élevée (' . $currentLoad . ').');
+            }
+
+            $this->scheduleRetry(
+                $retryDelay,
+                $batch,
+                $isFullScan,
+                $bypassRestWindow,
+                'server_load',
+                sprintf('BLC: Failed to schedule link batch #%d after high load.', $batch)
+            );
+            return true;
+        }
+
+        return false;
+    }
+
+    private function getCurrentHook(): string
+    {
+        if ($this->currentFilter !== null) {
+            return (string) call_user_func($this->currentFilter);
+        }
+
+        if (function_exists('current_filter')) {
+            return (string) current_filter();
+        }
+
+        return '';
+    }
+
+    private function now(): int
+    {
+        return (int) call_user_func($this->timeProvider);
+    }
+
+    private function log(string $message): void
+    {
+        call_user_func($this->errorLogger, $message);
+    }
+}

--- a/liens-morts-detector-jlg/includes/Scanner/RemoteRequestClient.php
+++ b/liens-morts-detector-jlg/includes/Scanner/RemoteRequestClient.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace JLG\BrokenLinks\Scanner;
+
+class RemoteRequestClient
+{
+    private int $linkDelayMs;
+    private float $lastCompletedAt = 0.0;
+
+    public function __construct(int $linkDelayMs)
+    {
+        if ($linkDelayMs < 0) {
+            $linkDelayMs = 0;
+        }
+
+        $this->linkDelayMs = $linkDelayMs;
+    }
+
+    public function waitForSlot(): void
+    {
+        if ($this->linkDelayMs <= 0) {
+            return;
+        }
+
+        $delaySeconds = $this->linkDelayMs / 1000;
+        if ($this->lastCompletedAt > 0) {
+            $elapsed = microtime(true) - $this->lastCompletedAt;
+            $remaining = $delaySeconds - $elapsed;
+            if ($remaining > 0) {
+                usleep((int) round($remaining * 1000000));
+            }
+        }
+    }
+
+    public function markRequestComplete(): void
+    {
+        $this->lastCompletedAt = microtime(true);
+    }
+
+    public function head(string $url, array $args = [])
+    {
+        $this->waitForSlot();
+        $response = wp_safe_remote_head($url, $args);
+        $this->markRequestComplete();
+
+        return $response;
+    }
+
+    public function get(string $url, array $args = [])
+    {
+        $this->waitForSlot();
+        $response = wp_safe_remote_get($url, $args);
+        $this->markRequestComplete();
+
+        return $response;
+    }
+}

--- a/liens-morts-detector-jlg/includes/Scanner/ScanQueue.php
+++ b/liens-morts-detector-jlg/includes/Scanner/ScanQueue.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace JLG\BrokenLinks\Scanner;
+
+use WP_Query;
+
+class ScanQueue
+{
+    private \wpdb $wpdb;
+    private int $batchSize;
+    private int $batchDelay;
+    private $scheduleEvent;
+    private $doAction;
+    private $errorLogger;
+    private $timeProvider;
+    private $postStatusResolver;
+    private $publicPostTypesResolver;
+
+    public function __construct(
+        \wpdb $wpdb,
+        int $batchSize,
+        int $batchDelay,
+        callable $scheduleEvent,
+        callable $doAction,
+        callable $errorLogger,
+        callable $timeProvider,
+        ?callable $postStatusResolver = null,
+        ?callable $publicPostTypesResolver = null
+    ) {
+        $this->wpdb = $wpdb;
+        $this->batchSize = $batchSize;
+        $this->batchDelay = max(0, $batchDelay);
+        $this->scheduleEvent = $scheduleEvent;
+        $this->doAction = $doAction;
+        $this->errorLogger = $errorLogger;
+        $this->timeProvider = $timeProvider;
+        $this->postStatusResolver = $postStatusResolver;
+        $this->publicPostTypesResolver = $publicPostTypesResolver;
+    }
+
+    /**
+     * @return array{posts: array<int, \WP_Post>, query: WP_Query}
+     */
+    public function loadBatch(int $batch, bool $isFullScan, int $lastCheckTime): array
+    {
+        $publicPostTypes = $this->resolvePublicPostTypes();
+        if ($publicPostTypes === []) {
+            $publicPostTypes = ['post'];
+        }
+
+        $args = [
+            'post_type'      => $publicPostTypes,
+            'post_status'    => $this->resolvePostStatuses(),
+            'posts_per_page' => $this->batchSize,
+            'paged'          => $batch + 1,
+        ];
+
+        if (!$isFullScan && $lastCheckTime > 0) {
+            $threshold = gmdate('Y-m-d H:i:s', $lastCheckTime);
+            $args['date_query'] = [[
+                'column' => 'post_modified_gmt',
+                'after'  => $threshold,
+            ]];
+        }
+
+        $query = new WP_Query($args);
+
+        return [
+            'posts' => $query->posts,
+            'query' => $query,
+        ];
+    }
+
+    public function scheduleNextBatchIfNeeded(
+        WP_Query $query,
+        int $currentBatch,
+        bool $isFullScan,
+        bool $bypassRestWindow
+    ): bool {
+        if ($query->max_num_pages > ($currentBatch + 1)) {
+            $timestamp = $this->now() + $this->batchDelay;
+            $scheduled = call_user_func(
+                $this->scheduleEvent,
+                $timestamp,
+                'blc_check_batch',
+                [$currentBatch + 1, $isFullScan, $bypassRestWindow]
+            );
+
+            if (false === $scheduled) {
+                call_user_func(
+                    $this->errorLogger,
+                    sprintf('BLC: Failed to schedule next link batch #%d.', $currentBatch + 1)
+                );
+                call_user_func(
+                    $this->doAction,
+                    'blc_check_batch_schedule_failed',
+                    $currentBatch + 1,
+                    $isFullScan,
+                    $bypassRestWindow,
+                    'next_batch'
+                );
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+
+    public function getBatchDelay(): int
+    {
+        return $this->batchDelay;
+    }
+
+    private function resolvePostStatuses(): array
+    {
+        if ($this->postStatusResolver !== null) {
+            $statuses = call_user_func($this->postStatusResolver);
+            if (is_array($statuses)) {
+                return $statuses;
+            }
+        }
+
+        $stored_statuses = blc_get_scannable_post_statuses();
+        return is_array($stored_statuses) ? $stored_statuses : ['publish'];
+    }
+
+    private function resolvePublicPostTypes(): array
+    {
+        if ($this->publicPostTypesResolver !== null) {
+            $postTypes = call_user_func($this->publicPostTypesResolver);
+            if (is_array($postTypes)) {
+                return $this->normalizePostTypes($postTypes);
+            }
+        }
+
+        $postTypes = get_post_types(['public' => true], 'names');
+        if (!is_array($postTypes)) {
+            $postTypes = [];
+        }
+
+        return $this->normalizePostTypes($postTypes);
+    }
+
+    private function normalizePostTypes(array $postTypes): array
+    {
+        return array_values(
+            array_filter(
+                array_map('strval', $postTypes),
+                static function ($postType) {
+                    return $postType !== '';
+                }
+            )
+        );
+    }
+
+    private function now(): int
+    {
+        return (int) call_user_func($this->timeProvider);
+    }
+}


### PR DESCRIPTION
## Summary
- extract the link scan orchestration into a LinkScanController that manages locking, rest windows, and queue scheduling
- introduce RemoteRequestClient and ScanQueue helpers to encapsulate remote throttling and batch retrieval logic
- wire blc_perform_check to the new classes and register the namespace with Composer autoloading

## Testing
- php -l liens-morts-detector-jlg/includes/blc-scanner.php

------
https://chatgpt.com/codex/tasks/task_e_68de450b41a0832e8a2cec272f3698f3