### PR TITLE
Add Brain Monkey scanner tests

### DIFF
--- a/tests/Scanner/LinkScanControllerTest.php
+++ b/tests/Scanner/LinkScanControllerTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Scanner;
+
+use Brain\Monkey\Functions;
+
+final class LinkScanControllerTest extends ScannerTestCase
+{
+    public function test_acquire_lock_generates_token_when_unlocked(): void
+    {
+        Functions\when('blc_generate_lock_token')->alias(fn() => 'lock-token');
+
+        $token = blc_acquire_link_scan_lock(300);
+
+        $this->assertSame('lock-token', $token);
+        $this->assertSame(
+            [
+                'token'     => 'lock-token',
+                'locked_at' => $this->currentTime,
+            ],
+            $this->options['blc_link_scan_lock'] ?? null,
+            'Lock state should be stored with the generated token.'
+        );
+        $this->assertSame(
+            'lock-token',
+            $this->options['blc_link_scan_lock_token'] ?? null,
+            'Token mirror option should be updated for watchdog checks.'
+        );
+    }
+
+    public function test_acquire_lock_returns_empty_string_when_lock_is_active(): void
+    {
+        $this->options['blc_link_scan_lock'] = [
+            'token'     => 'existing-token',
+            'locked_at' => $this->currentTime,
+        ];
+
+        $token = blc_acquire_link_scan_lock(120);
+
+        $this->assertSame('', $token);
+        $this->assertSame(
+            'existing-token',
+            $this->options['blc_link_scan_lock']['token'] ?? null,
+            'Existing lock token should remain untouched when lock is active.'
+        );
+        $this->assertArrayNotHasKey(
+            'blc_link_scan_lock_token',
+            $this->options,
+            'Mirror token option should not be overwritten when acquisition fails.'
+        );
+    }
+
+    public function test_release_lock_clears_stored_options(): void
+    {
+        $this->options['blc_link_scan_lock'] = [
+            'token'     => 'release-me',
+            'locked_at' => $this->currentTime,
+        ];
+        $this->options['blc_link_scan_lock_token'] = 'release-me';
+
+        blc_release_link_scan_lock('release-me');
+
+        $this->assertArrayNotHasKey('blc_link_scan_lock', $this->options);
+        $this->assertArrayNotHasKey('blc_link_scan_lock_token', $this->options);
+    }
+
+    public function test_perform_check_reschedules_batch_inside_rest_window(): void
+    {
+        $this->options['blc_rest_start_hour'] = '08';
+        $this->options['blc_rest_end_hour'] = '20';
+        $this->options['blc_batch_delay'] = 300;
+        $this->options['blc_debug_mode'] = false;
+
+        $this->setCurrentTime(strtotime('2023-01-01 12:34:00 UTC'));
+
+        Functions\when('blc_acquire_link_scan_lock')->alias(fn() => 'token-123');
+        Functions\expect('blc_release_link_scan_lock')->once()->with('token-123');
+        Functions\when('current_filter')->alias(fn() => 'blc_check_links');
+
+        blc_perform_check(0, true);
+
+        $this->assertCount(1, $this->scheduledEvents, 'A follow-up batch should be scheduled during the rest window.');
+        $scheduled = $this->scheduledEvents[0];
+        $this->assertSame('blc_check_batch', $scheduled['hook']);
+        $this->assertSame([0, true, false], $scheduled['args']);
+        $this->assertSame(
+            strtotime('2023-01-01 20:00:00 UTC'),
+            $scheduled['timestamp'],
+            'Next run should align with the configured rest window exit.'
+        );
+    }
+}

--- a/tests/Scanner/RemoteRequestClientTest.php
+++ b/tests/Scanner/RemoteRequestClientTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Scanner;
+
+use Brain\Monkey\Functions;
+
+final class RemoteRequestClientTest extends ScannerTestCase
+{
+    public function test_get_request_timeout_constraints_merges_filter_values(): void
+    {
+        Functions\when('apply_filters')->alias(function ($hook, $value, ...$args) {
+            if ($hook === 'blc_request_timeout_constraints') {
+                return [
+                    'head' => ['default' => 8, 'min' => 2, 'max' => 12],
+                    'get'  => ['default' => 15, 'min' => 5, 'max' => 45],
+                ];
+            }
+
+            return $value;
+        });
+
+        $constraints = blc_get_request_timeout_constraints();
+
+        $this->assertSame(
+            ['default' => 8.0, 'min' => 2.0, 'max' => 12.0],
+            $constraints['head']
+        );
+        $this->assertSame(
+            ['default' => 15.0, 'min' => 5.0, 'max' => 45.0],
+            $constraints['get']
+        );
+    }
+
+    public function test_normalize_timeout_option_clamps_and_parses_values(): void
+    {
+        $this->assertSame(4.5, blc_normalize_timeout_option('4,5', 5.0, 1.0, 10.0));
+        $this->assertSame(1.0, blc_normalize_timeout_option('0', 5.0, 1.0, 10.0));
+        $this->assertSame(10.0, blc_normalize_timeout_option('50', 5.0, 1.0, 10.0));
+        $this->assertSame(5.0, blc_normalize_timeout_option('n/a', 5.0, 1.0, 10.0));
+    }
+
+    public function test_is_public_ip_address_rejects_private_and_loopback_ranges(): void
+    {
+        $this->assertFalse(blc_is_public_ip_address('192.168.1.20'));
+        $this->assertFalse(blc_is_public_ip_address('127.0.0.1'));
+        $this->assertFalse(blc_is_public_ip_address('::1'));
+        $this->assertFalse(blc_is_public_ip_address('fe80::1'));
+    }
+
+    public function test_is_public_ip_address_accepts_public_addresses(): void
+    {
+        $this->assertTrue(blc_is_public_ip_address('93.184.216.34'));
+        $this->assertTrue(blc_is_public_ip_address('2001:4860:4860::8888'));
+    }
+
+    public function test_normalize_remote_host_lowercases_and_trims(): void
+    {
+        $this->assertSame('example.com', blc_normalize_remote_host(' Example.COM '));
+        $this->assertSame('2001:db8::1', blc_normalize_remote_host('2001:DB8::1'));
+        $this->assertSame('203.0.113.5', blc_normalize_remote_host('203.0.113.5'));
+    }
+}

--- a/tests/Scanner/ScanQueueTest.php
+++ b/tests/Scanner/ScanQueueTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Tests\Scanner;
+
+use Brain\Monkey\Functions;
+
+final class ScanQueueTest extends ScannerTestCase
+{
+    public function test_get_scan_cache_context_reuses_existing_cache(): void
+    {
+        $this->options['blc_active_link_scan_key'] = 'existing-key';
+        $transient = blc_build_scan_cache_transient_name('link', 'existing-key');
+        $this->transients[$transient] = [
+            'value'      => ['cached' => ['foo' => 'bar']],
+            'expiration' => 3600,
+        ];
+
+        $context = blc_get_scan_cache_context('link', 1);
+
+        $this->assertSame('existing-key', $context['key']);
+        $this->assertSame('blc_active_link_scan_key', $context['option']);
+        $this->assertSame(
+            ['cached' => ['foo' => 'bar']],
+            $context['data'],
+            'Stored scan cache should be loaded when a key is present.'
+        );
+    }
+
+    public function test_get_scan_cache_context_generates_new_key_for_first_batch(): void
+    {
+        $context = blc_get_scan_cache_context('link', 0);
+
+        $this->assertArrayHasKey('key', $context);
+        $this->assertNotSame('', $context['key']);
+        $this->assertSame('blc_active_link_scan_key', $context['option']);
+        $this->assertSame(
+            $context['key'],
+            $this->options['blc_active_link_scan_key'] ?? '',
+            'Fresh scan key should be persisted for subsequent batches.'
+        );
+        $this->assertSame([], $context['data']);
+    }
+
+    public function test_save_scan_cache_persists_payload_with_filtered_expiration(): void
+    {
+        $context = blc_get_scan_cache_context('link', 0);
+        $transientName = $context['transient'];
+
+        Functions\when('apply_filters')->alias(function ($hook, $value, ...$args) use ($context) {
+            if ($hook === 'blc_scan_cache_expiration') {
+                return 7200;
+            }
+
+            return $value;
+        });
+
+        $payload = ['items' => [1, 2, 3]];
+        blc_save_scan_cache($context, $payload);
+
+        $this->assertSame($payload, $context['data']);
+        $this->assertArrayHasKey($transientName, $this->transients);
+        $this->assertSame($payload, $this->transients[$transientName]['value']);
+        $this->assertSame(7200, $this->transients[$transientName]['expiration']);
+    }
+
+    public function test_clear_scan_cache_removes_transient_and_active_option(): void
+    {
+        $context = blc_get_scan_cache_context('link', 0);
+        blc_save_scan_cache($context, ['foo' => 'bar']);
+
+        blc_clear_scan_cache($context);
+
+        $this->assertArrayNotHasKey($context['transient'], $this->transients);
+        $this->assertArrayNotHasKey('blc_active_link_scan_key', $this->options);
+    }
+}

--- a/tests/Scanner/ScannerTestCase.php
+++ b/tests/Scanner/ScannerTestCase.php
@@ -1,0 +1,346 @@
+<?php
+
+namespace {
+    require_once __DIR__ . '/../../vendor/autoload.php';
+
+    if (!class_exists('WP_Error')) {
+        class WP_Error
+        {
+            /** @var string */
+            private $code;
+
+            /** @var string */
+            private $message;
+
+            /** @var mixed */
+            private $data;
+
+            public function __construct($code = '', $message = '', $data = null)
+            {
+                $this->code = (string) $code;
+                $this->message = (string) $message;
+                $this->data = $data;
+            }
+
+            public function get_error_code()
+            {
+                return $this->code;
+            }
+
+            public function get_error_message()
+            {
+                return $this->message;
+            }
+
+            public function get_error_data()
+            {
+                return $this->data;
+            }
+        }
+    }
+
+    if (!defined('HOUR_IN_SECONDS')) {
+        define('HOUR_IN_SECONDS', 3600);
+    }
+
+    if (!defined('MINUTE_IN_SECONDS')) {
+        define('MINUTE_IN_SECONDS', 60);
+    }
+
+    if (!defined('ABSPATH')) {
+        define('ABSPATH', __DIR__ . '/../..');
+    }
+
+}
+
+namespace Tests\Scanner {
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery;
+use PHPUnit\Framework\TestCase;
+
+abstract class ScannerTestCase extends TestCase
+{
+    /** @var array<string, mixed> */
+    protected array $options = [];
+
+    /** @var array<string, array{value:mixed,expiration:int}> */
+    protected array $transients = [];
+
+    /** @var array<int, array{timestamp:int,hook:string,args:array}> */
+    protected array $scheduledEvents = [];
+
+    /** @var int */
+    protected int $currentTime = 1_700_000_000;
+
+    /** @var object|null */
+    protected $wpdb;
+
+    private static bool $bootstrapped = false;
+    private static bool $pluginLoaded = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (self::$bootstrapped) {
+            return;
+        }
+
+        require_once __DIR__ . '/../../vendor/autoload.php';
+        require_once __DIR__ . '/../translation-stubs.php';
+
+        self::$bootstrapped = true;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Monkey\setUp();
+
+        if (!self::$pluginLoaded) {
+            require_once __DIR__ . '/../../liens-morts-detector-jlg/includes/blc-utils.php';
+            require_once __DIR__ . '/../../liens-morts-detector-jlg/includes/blc-scanner.php';
+            self::$pluginLoaded = true;
+        }
+
+        $this->options = [];
+        $this->transients = [];
+        $this->scheduledEvents = [];
+        $this->currentTime = 1_700_000_000;
+
+        $this->wpdb = new class {
+            public string $prefix = 'wp_';
+
+            /** @var array<int, string> */
+            public array $queries = [];
+
+            public function prepare($query, ...$args)
+            {
+                return $query;
+            }
+
+            public function get_var($query)
+            {
+                $this->queries[] = (string) $query;
+                return 0;
+            }
+
+            public function query($query)
+            {
+                $this->queries[] = (string) $query;
+                return 0;
+            }
+        };
+
+        $GLOBALS['wpdb'] = $this->wpdb;
+
+        $this->stubWordPressFunctions();
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['wpdb']);
+        Mockery::close();
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    protected function setCurrentTime(int $timestamp): void
+    {
+        $this->currentTime = $timestamp;
+    }
+
+    private function stubWordPressFunctions(): void
+    {
+        Functions\when('get_option')->alias(function ($name, $default = false) {
+            return $this->options[$name] ?? $default;
+        });
+
+        Functions\when('update_option')->alias(function ($name, $value, $autoload = null) {
+            $this->options[$name] = $value;
+            return true;
+        });
+
+        Functions\when('delete_option')->alias(function ($name) {
+            unset($this->options[$name]);
+            return true;
+        });
+
+        Functions\when('get_transient')->alias(function ($key) {
+            $entry = $this->transients[$key] ?? false;
+            if (is_array($entry) && array_key_exists('value', $entry)) {
+                return $entry['value'];
+            }
+
+            return $entry;
+        });
+
+        Functions\when('set_transient')->alias(function ($key, $value, $expiration) {
+            $this->transients[$key] = [
+                'value'      => $value,
+                'expiration' => (int) $expiration,
+            ];
+            return true;
+        });
+
+        Functions\when('delete_transient')->alias(function ($key) {
+            unset($this->transients[$key]);
+            return true;
+        });
+
+        Functions\when('apply_filters')->alias(fn($hook, $value, ...$args) => $value);
+        Functions\when('do_action')->alias(function () {
+        });
+
+        Functions\when('home_url')->alias(function ($path = '', $scheme = null) {
+            $path = (string) $path;
+            if ($path === '') {
+                return 'https://example.com';
+            }
+
+            return 'https://example.com/' . ltrim($path, '/');
+        });
+
+        Functions\when('site_url')->alias(function ($path = '', $scheme = null) {
+            $path = (string) $path;
+            if ($path === '') {
+                return 'https://example.com';
+            }
+
+            return 'https://example.com/' . ltrim($path, '/');
+        });
+
+        Functions\when('admin_url')->alias(function ($path = '', $scheme = 'admin') {
+            return 'https://example.com/wp-admin/' . ltrim((string) $path, '/');
+        });
+
+        Functions\when('wp_parse_url')->alias(fn($url, $component = -1) => parse_url($url, $component));
+        Functions\when('trailingslashit')->alias(fn($value) => rtrim((string) $value, "/\\") . '/');
+        Functions\when('wp_normalize_path')->alias(fn($path) => str_replace('\\', '/', (string) $path));
+
+        Functions\when('wp_list_pluck')->alias(function ($input, $field) {
+            $result = [];
+            foreach ($input as $item) {
+                if (is_array($item) && array_key_exists($field, $item)) {
+                    $result[] = $item[$field];
+                } elseif (is_object($item) && isset($item->$field)) {
+                    $result[] = $item->$field;
+                }
+            }
+            return $result;
+        });
+
+        Functions\when('wp_schedule_single_event')->alias(function ($timestamp, $hook, $args = []) {
+            $this->scheduledEvents[] = [
+                'timestamp' => (int) $timestamp,
+                'hook'      => (string) $hook,
+                'args'      => is_array($args) ? $args : [$args],
+            ];
+            return true;
+        });
+
+        Functions\when('wp_next_scheduled')->alias(fn($hook) => false);
+
+        Functions\when('current_filter')->alias(fn() => '');
+
+        Functions\when('time')->alias(fn() => $this->currentTime);
+        Functions\when('current_time')->alias(function ($type, $gmt = 0) {
+            $type = (string) $type;
+            if ($type === 'timestamp') {
+                return $this->currentTime;
+            }
+            if ($type === 'mysql') {
+                return gmdate('Y-m-d H:i:s', $this->currentTime);
+            }
+            if ($type === 'H') {
+                return gmdate('H', $this->currentTime);
+            }
+
+            return $this->currentTime;
+        });
+
+        Functions\when('wp_timezone')->alias(fn() => new \DateTimeZone('UTC'));
+        Functions\when('wp_timezone_string')->alias(fn() => 'UTC');
+
+        Functions\when('wp_safe_remote_head')->alias(fn($url, $args = []) => ['response' => ['code' => 200]]);
+        Functions\when('wp_safe_remote_get')->alias(fn($url, $args = []) => ['response' => ['code' => 200]]);
+        Functions\when('wp_remote_retrieve_response_code')->alias(function ($response) {
+            if (is_array($response) && isset($response['response']['code'])) {
+                return (int) $response['response']['code'];
+            }
+            return 0;
+        });
+
+        Functions\when('is_wp_error')->alias(fn($thing) => $thing instanceof \WP_Error);
+
+        Functions\when('sanitize_text_field')->alias(function ($text) {
+            if (is_scalar($text)) {
+                return trim((string) $text);
+            }
+
+            return '';
+        });
+
+        if (!function_exists('sanitize_email')) {
+            Functions\when('sanitize_email')->alias(function ($email) {
+                if (!is_string($email)) {
+                    return '';
+                }
+
+                return filter_var($email, FILTER_SANITIZE_EMAIL) ?: '';
+            });
+        }
+
+        if (!function_exists('is_email')) {
+            Functions\when('is_email')->alias(function ($email) {
+                return is_string($email) && filter_var($email, FILTER_VALIDATE_EMAIL) !== false;
+            });
+        }
+
+        if (!function_exists('sanitize_key')) {
+            Functions\when('sanitize_key')->alias(function ($key) {
+                $key = strtolower(is_scalar($key) ? (string) $key : '');
+
+                return preg_replace('/[^a-z0-9_\-]/', '', $key);
+            });
+        }
+
+        Functions\when('maybe_unserialize')->alias(function ($value) {
+            if (!is_string($value)) {
+                return $value;
+            }
+            $unserialized = @unserialize($value);
+            return $unserialized === false && $value !== 'b:0;' ? $value : $unserialized;
+        });
+        Functions\when('maybe_serialize')->alias(fn($value) => serialize($value));
+
+        Functions\when('wp_generate_password')->alias(function ($length = 12) {
+            $length = max(1, (int) $length);
+            return substr(str_repeat('a', $length), 0, $length);
+        });
+
+        Functions\when('wp_upload_dir')->alias(fn() => [
+            'baseurl' => 'https://example.com/wp-content/uploads',
+            'basedir' => '/var/www/html/wp-content/uploads',
+            'error'   => false,
+        ]);
+
+        Functions\when('sys_getloadavg')->alias(fn() => [0.1, 0.1, 0.1]);
+
+        Functions\when('wp_mail')->alias(function ($to, $subject, $message) {
+            return true;
+        });
+
+        Functions\when('wp_unslash')->alias(fn($value) => $value);
+        Functions\when('wp_json_encode')->alias(fn($value) => json_encode($value));
+
+        Functions\when('wp_safe_redirect')->alias(function ($location, $status = 302) {
+            return true;
+        });
+
+        Functions\when('wp_remote_retrieve_headers')->alias(fn($response) => []);
+        Functions\when('wp_remote_retrieve_header')->alias(fn($response, $header) => null);
+    }
+}
+
+}


### PR DESCRIPTION
## Summary
- add a shared ScannerTestCase that boots Brain Monkey and WordPress shims for scanner-focused tests
- cover link scan locking and rest-window scheduling with LinkScanController tests
- validate ScanQueue cache management and RemoteRequestClient helpers

## Testing
- vendor/bin/phpunit tests/Scanner
- vendor/bin/phpunit tests


------
https://chatgpt.com/codex/tasks/task_e_68de4558c030832e972fb0bd926b8984