### PR TITLE
Add HTTP status badges and legend

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -38,6 +38,79 @@
     color: #50575e;
 }
 
+/* Styles pour les badges de statut HTTP */
+.blc-status {
+    display: inline-flex;
+    align-items: center;
+    padding: 0.1rem 0.55rem;
+    border-radius: 999px;
+    font-size: 12px;
+    line-height: 1.4;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    background-color: #374151;
+    color: #f9fafb;
+    font-variant-numeric: tabular-nums;
+    text-transform: none;
+}
+
+.blc-status--2xx {
+    background-color: #0f5132;
+    color: #f8fafc;
+}
+
+.blc-status--3xx {
+    background-color: #92400e;
+    color: #fef3c7;
+}
+
+.blc-status--4xx,
+.blc-status--5xx {
+    background-color: #7f1d1d;
+    color: #fef2f2;
+}
+
+.blc-status--unknown {
+    background-color: #4b5563;
+    color: #f9fafb;
+}
+
+/* Styles pour la légende des statuts HTTP */
+.blc-status-legend {
+    margin: 16px 0;
+    padding: 12px 16px;
+    border: 1px solid #d0d1d4;
+    border-radius: 6px;
+    background-color: #f6f7f7;
+}
+
+.blc-status-legend__title {
+    margin: 0 0 8px;
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.blc-status-legend__list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px 20px;
+}
+
+.blc-status-legend__item {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    color: #1d2327;
+    font-size: 13px;
+}
+
+.blc-status-legend__item span:last-child {
+    line-height: 1.3;
+}
+
 @media (max-width: 782px) {
     .blc-stats-box {
         flex-direction: column;

--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -225,6 +225,31 @@ function blc_dashboard_links_page() {
         <?php if ($broken_links_count === 0): ?>
              <p><?php esc_html_e('✅ Aucun lien mort trouvé. Bravo !', 'liens-morts-detector-jlg'); ?></p>
         <?php else: ?>
+            <div class="blc-status-legend" role="note">
+                <p class="blc-status-legend__title"><?php esc_html_e('Légende des statuts HTTP', 'liens-morts-detector-jlg'); ?></p>
+                <ul class="blc-status-legend__list">
+                    <li class="blc-status-legend__item">
+                        <span class="blc-status blc-status--2xx">200</span>
+                        <span><?php esc_html_e('Disponible (2xx)', 'liens-morts-detector-jlg'); ?></span>
+                    </li>
+                    <li class="blc-status-legend__item">
+                        <span class="blc-status blc-status--3xx">302</span>
+                        <span><?php esc_html_e('Redirection (3xx)', 'liens-morts-detector-jlg'); ?></span>
+                    </li>
+                    <li class="blc-status-legend__item">
+                        <span class="blc-status blc-status--4xx">404</span>
+                        <span><?php esc_html_e('Erreur client (4xx)', 'liens-morts-detector-jlg'); ?></span>
+                    </li>
+                    <li class="blc-status-legend__item">
+                        <span class="blc-status blc-status--5xx">502</span>
+                        <span><?php esc_html_e('Erreur serveur (5xx)', 'liens-morts-detector-jlg'); ?></span>
+                    </li>
+                    <li class="blc-status-legend__item">
+                        <span class="blc-status blc-status--unknown">?</span>
+                        <span><?php esc_html_e('Statut inconnu ou indisponible', 'liens-morts-detector-jlg'); ?></span>
+                    </li>
+                </ul>
+            </div>
             <form method="get" class="blc-links-filter-form" aria-labelledby="blc-links-filter-heading">
                 <h2 id="blc-links-filter-heading" class="screen-reader-text"><?php esc_html_e('Filtres de la liste des liens cassés', 'liens-morts-detector-jlg'); ?></h2>
                 <?php

--- a/liens-morts-detector-jlg/includes/class-blc-images-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-images-list-table.php
@@ -147,11 +147,49 @@ class BLC_Images_List_Table extends WP_List_Table {
             return esc_html__('—', 'liens-morts-detector-jlg');
         }
 
+        $classes = ['blc-status'];
+        $label = (string) $raw_status;
+
         if (is_numeric($raw_status)) {
-            $raw_status = (int) $raw_status;
+            $status_code = (int) $raw_status;
+            $label = (string) $status_code;
+
+            if ($status_code >= 200 && $status_code < 300) {
+                $classes[] = 'blc-status--2xx';
+            } elseif ($status_code >= 300 && $status_code < 400) {
+                $classes[] = 'blc-status--3xx';
+            } elseif ($status_code >= 400 && $status_code < 500) {
+                $classes[] = 'blc-status--4xx';
+            } elseif ($status_code >= 500 && $status_code < 600) {
+                $classes[] = 'blc-status--5xx';
+            } else {
+                $classes[] = 'blc-status--unknown';
+            }
+
+            $classes[] = 'blc-status--' . $status_code;
+        } else {
+            $classes[] = 'blc-status--unknown';
+            $classes[] = 'blc-status--' . strtolower((string) $raw_status);
         }
 
-        return esc_html((string) $raw_status);
+        $sanitized_classes = array_map(
+            static function ($class) {
+                if (function_exists('sanitize_html_class')) {
+                    return sanitize_html_class($class);
+                }
+
+                return preg_replace('/[^A-Za-z0-9_-]/', '', (string) $class);
+            },
+            $classes
+        );
+
+        $class_attribute = implode(' ', array_filter(array_unique($sanitized_classes)));
+
+        return sprintf(
+            '<span class="%s">%s</span>',
+            esc_attr($class_attribute),
+            esc_html($label)
+        );
     }
 
     protected function column_last_checked_at($item) {

--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -325,11 +325,49 @@ class BLC_Links_List_Table extends WP_List_Table {
             return esc_html__('—', 'liens-morts-detector-jlg');
         }
 
+        $classes = ['blc-status'];
+        $label = (string) $raw_status;
+
         if (is_numeric($raw_status)) {
-            $raw_status = (int) $raw_status;
+            $status_code = (int) $raw_status;
+            $label = (string) $status_code;
+
+            if ($status_code >= 200 && $status_code < 300) {
+                $classes[] = 'blc-status--2xx';
+            } elseif ($status_code >= 300 && $status_code < 400) {
+                $classes[] = 'blc-status--3xx';
+            } elseif ($status_code >= 400 && $status_code < 500) {
+                $classes[] = 'blc-status--4xx';
+            } elseif ($status_code >= 500 && $status_code < 600) {
+                $classes[] = 'blc-status--5xx';
+            } else {
+                $classes[] = 'blc-status--unknown';
+            }
+
+            $classes[] = 'blc-status--' . $status_code;
+        } else {
+            $classes[] = 'blc-status--unknown';
+            $classes[] = 'blc-status--' . strtolower((string) $raw_status);
         }
 
-        return esc_html((string) $raw_status);
+        $sanitized_classes = array_map(
+            static function ($class) {
+                if (function_exists('sanitize_html_class')) {
+                    return sanitize_html_class($class);
+                }
+
+                return preg_replace('/[^A-Za-z0-9_-]/', '', (string) $class);
+            },
+            $classes
+        );
+
+        $class_attribute = implode(' ', array_filter(array_unique($sanitized_classes)));
+
+        return sprintf(
+            '<span class="%s">%s</span>',
+            esc_attr($class_attribute),
+            esc_html($label)
+        );
     }
 
     protected function column_last_checked_at($item) {

--- a/tests/AdminListTablesTest.php
+++ b/tests/AdminListTablesTest.php
@@ -179,7 +179,7 @@ class AdminListTablesTest extends TestCase
             'url'             => 'https://example.com',
         ];
 
-        $this->assertSame('410', $table->renderHttpStatus($item));
+        $this->assertSame('<span class="blc-status blc-status--4xx blc-status--410">410</span>', $table->renderHttpStatus($item));
         $this->assertSame('1970-01-01 00:00', $table->renderLastChecked($item));
 
         $empty = [


### PR DESCRIPTION
## Summary
- render HTTP status codes as color-coded badges in the links and images list tables with sanitised CSS classes
- style the new HTTP status badges and add a legend explaining each colour on the links dashboard
- update the admin list table test expectations for the badge markup

## Testing
- ./vendor/bin/phpunit tests

------
https://chatgpt.com/codex/tasks/task_e_68de66552040832eb30dbe9743676f06