### PR TITLE
Convert broken link row actions to buttons

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -163,6 +163,7 @@
 
     .wp-list-table td .row-actions span {
         display: inline-flex;
+        align-items: center;
     }
 
     .wp-list-table td.column-image_details .blc-image-details {
@@ -177,6 +178,36 @@
 
     .blc-image-preview__img {
         max-height: 160px;
+    }
+}
+
+.wp-list-table td .row-actions button.button-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 10px;
+    border-radius: 4px;
+    line-height: 1.5;
+}
+
+.wp-list-table td .row-actions button.button-link:focus-visible {
+    outline: 2px solid #72aee6;
+    outline-offset: 1px;
+}
+
+@media (max-width: 782px) {
+    .wp-list-table td .row-actions {
+        gap: 10px;
+    }
+
+    .wp-list-table td .row-actions span {
+        width: 100%;
+    }
+
+    .wp-list-table td .row-actions button.button-link {
+        width: 100%;
+        justify-content: flex-start;
+        text-align: left;
     }
 }
 

--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -381,7 +381,7 @@ class BLC_Links_List_Table extends WP_List_Table {
         $data_attributes = implode(' ', $data_attributes);
 
         $actions['edit_link'] = sprintf(
-            '<a href="#" class="blc-edit-link" %s data-nonce="%s">%s</a>',
+            '<button type="button" class="button button-small button-link blc-edit-link" %s data-nonce="%s">%s</button>',
             $data_attributes,
             wp_create_nonce('blc_edit_link_nonce'),
             esc_html__('Modifier', 'liens-morts-detector-jlg')
@@ -402,14 +402,14 @@ class BLC_Links_List_Table extends WP_List_Table {
             : esc_html__('Ignorer', 'liens-morts-detector-jlg');
 
         $actions['ignore'] = sprintf(
-            '<a href="#" class="blc-ignore" %s data-ignore-mode="%s" data-nonce="%s">%s</a>',
+            '<button type="button" class="button button-small button-link blc-ignore" %s data-ignore-mode="%s" data-nonce="%s">%s</button>',
             $data_attributes,
             esc_attr($ignore_mode),
             wp_create_nonce('blc_ignore_link_nonce'),
             $ignore_label
         );
         $actions['unlink'] = sprintf(
-            '<a href="#" class="blc-unlink" %s data-nonce="%s" style="color:#a00;">%s</a>',
+            '<button type="button" class="button button-small button-link blc-unlink" %s data-nonce="%s" style="color:#a00;">%s</button>',
             $data_attributes,
             wp_create_nonce('blc_unlink_nonce'),
             esc_html__('Dissocier', 'liens-morts-detector-jlg')


### PR DESCRIPTION
## Summary
- replace the row action anchor tags with button elements while preserving existing data attributes and .blc-* hooks
- adjust the admin stylesheet to enlarge the button hit area and keep actions aligned on smaller screens

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de66516ae0832eb0458149d75d5057