### PR TITLE
Add configurable public post type selection

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -328,14 +328,8 @@ if (!class_exists('ScanQueue')) {
             $last_check_time = (int) get_option('blc_last_check_time', 0);
             $table_name      = $wpdb->prefix . 'blc_broken_links';
 
-            $public_post_types = get_post_types(['public' => true], 'names');
-            if (!is_array($public_post_types)) {
-                $public_post_types = [];
-            }
-            $public_post_types = array_values(array_filter(array_map('strval', $public_post_types), static function ($post_type) {
-                return $post_type !== '';
-            }));
-            if ($public_post_types === []) {
+            $public_post_types = blc_get_configured_post_types();
+            if (!is_array($public_post_types) || $public_post_types === []) {
                 $public_post_types = ['post'];
             }
 
@@ -1612,14 +1606,8 @@ if (!class_exists('ImageScanQueue')) {
             }
 
             $batch_size = 20;
-            $public_post_types = get_post_types(['public' => true], 'names');
-            if (!is_array($public_post_types)) {
-                $public_post_types = [];
-            }
-            $public_post_types = array_values(array_filter(array_map('strval', $public_post_types), static function ($post_type) {
-                return $post_type !== '';
-            }));
-            if ($public_post_types === []) {
+            $public_post_types = blc_get_configured_post_types();
+            if (!is_array($public_post_types) || $public_post_types === []) {
                 $public_post_types = ['post'];
             }
 

--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -678,24 +678,34 @@ class BLC_Links_List_Table extends WP_List_Table {
     }
 
     private function get_available_post_types() {
-        if (!function_exists('get_post_types')) {
+        if (!function_exists('blc_get_configured_post_types')) {
             return [];
         }
 
-        $post_types = get_post_types(['public' => true]);
+        $post_types = blc_get_configured_post_types();
         if (!is_array($post_types)) {
-            return [];
+            $post_types = [];
         }
 
         $available_post_types = [];
-
         foreach ($post_types as $post_type) {
-            if (is_string($post_type) && $post_type !== '') {
-                $available_post_types[] = $post_type;
+            if (!is_scalar($post_type)) {
+                continue;
             }
+
+            $post_type_key = sanitize_key((string) $post_type);
+            if ($post_type_key === '') {
+                continue;
+            }
+
+            $available_post_types[$post_type_key] = $post_type_key;
         }
 
-        return array_values(array_unique($available_post_types));
+        if ($available_post_types === []) {
+            $available_post_types = ['post'];
+        }
+
+        return array_values($available_post_types);
     }
 
     private function get_selected_post_type() {


### PR DESCRIPTION
## Summary
- add a persisted option for selecting which public post types are scanned by the plugin and expose it in the Performance section of the settings page
- sanitize and default the stored types while migrating existing installs to the full public list
- reuse the configured post types inside the scanner and list table queries instead of always using every public type

## Testing
- `php -l liens-morts-detector-jlg/includes/blc-utils.php`
- `php -l liens-morts-detector-jlg/includes/blc-settings-fields.php`
- `php -l liens-morts-detector-jlg/includes/blc-scanner.php`
- `php -l liens-morts-detector-jlg/includes/class-blc-links-list-table.php`

------
https://chatgpt.com/codex/tasks/task_e_68de8adea82c832eacde12a0588eee60