### PR TITLE
Adjust mobile table labels separator handling

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -204,7 +204,7 @@
     }
 
     .wp-list-table td::before {
-        content: attr(data-colname) ":";
+        content: attr(data-colname);
         font-weight: 600;
         color: #50575e;
         flex: 0 0 clamp(96px, 42%, 180px);
@@ -214,6 +214,10 @@
         margin-right: 6px;
         text-transform: none;
         letter-spacing: 0;
+    }
+
+    .wp-list-table td[data-colname]:not([data-colname=""])::after {
+        content: ": ";
     }
 
     .wp-list-table td.column-primary {


### PR DESCRIPTION
## Summary
- stop concatenating the separator in the `.wp-list-table td::before` pseudo-element so empty labels no longer render stray colons
- append the separator via a dedicated `::after` rule that only applies when `data-colname` is defined

## Testing
- not run (CSS change)


------
https://chatgpt.com/codex/tasks/task_e_68debe3c60d0832e8a8ed72595d6f2f5