### PR TITLE
Add webhook notifications to scan summaries

### DIFF
--- a/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
+++ b/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
@@ -135,6 +135,9 @@ jQuery(document).ready(function($) {
         var $recipients = $('#blc_notification_recipients');
         var $linkToggle = $('#blc_notification_links_enabled');
         var $imageToggle = $('#blc_notification_images_enabled');
+        var $webhookUrl = $('#blc_notification_webhook_url');
+        var $webhookChannel = $('#blc_notification_webhook_channel');
+        var $messageTemplate = $('#blc_notification_message_template');
         var isSending = false;
 
         function ensureFeedbackContainer() {
@@ -201,7 +204,21 @@ jQuery(document).ready(function($) {
                 recipientsValue = $recipients.val();
             }
 
-            if (!recipientsValue || $.trim(String(recipientsValue)) === '') {
+            var hasRecipients = recipientsValue && $.trim(String(recipientsValue)) !== '';
+            var webhookUrlValue = '';
+            var webhookChannelValue = '';
+
+            if ($webhookUrl.length) {
+                webhookUrlValue = $.trim(String($webhookUrl.val()));
+            }
+
+            if ($webhookChannel.length) {
+                webhookChannelValue = String($webhookChannel.val());
+            }
+
+            var hasWebhook = webhookUrlValue !== '' && webhookChannelValue && webhookChannelValue !== 'disabled';
+
+            if (!hasRecipients && !hasWebhook) {
                 showFeedback('warning', config.missingRecipientsText || '');
                 return;
             }
@@ -234,7 +251,10 @@ jQuery(document).ready(function($) {
                 action: config.action,
                 _ajax_nonce: config.nonce,
                 recipients: recipientsValue,
-                dataset_types: datasetTypes
+                dataset_types: datasetTypes,
+                webhook_url: webhookUrlValue,
+                webhook_channel: webhookChannelValue,
+                message_template: $messageTemplate.length ? $messageTemplate.val() : ''
             }).done(function(response) {
                 if (response && response.success) {
                     var message = (response.data && response.data.message) ? response.data.message : (config.successText || '');


### PR DESCRIPTION
## Summary
- expose webhook URL, channel selector, and template controls in the notification settings UI with proper sanitization
- send scan summaries via email and optional webhooks while logging failures and reusing the templated payload
- update the test notification AJAX flow to cover webhook dispatch and surface channel-specific results in the admin

## Testing
- php -l liens-morts-detector-jlg/includes/blc-settings-fields.php
- php -l liens-morts-detector-jlg/includes/blc-scanner.php
- php -l liens-morts-detector-jlg/liens-morts-detector-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68dec53552cc832e8912982a1eaabddf