### PR TITLE
Add mobile filters and navigation for link dashboard

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -38,6 +38,30 @@
     color: #50575e;
 }
 
+/* Navigation et filtres pour mobiles */
+.blc-mobile-only {
+    display: none;
+}
+
+.blc-dashboard-nav {
+    margin: 16px 0 12px;
+}
+
+.blc-link-type-select-wrapper {
+    margin-bottom: 12px;
+}
+
+.blc-link-type-select {
+    width: 100%;
+    max-width: 100%;
+    padding: 6px 10px;
+    border-radius: 4px;
+    border: 1px solid #c3c4c7;
+    background-color: #fff;
+    font-size: 14px;
+    color: #1d2327;
+}
+
 /* Styles pour les badges de statut HTTP */
 .blc-status {
     display: inline-flex;
@@ -121,6 +145,36 @@
         width: 100%;
         flex: 1 1 100%;
         padding: 12px 0;
+    }
+
+    .blc-mobile-only {
+        display: block;
+    }
+
+    .blc-dashboard-nav {
+        display: flex;
+        gap: 8px;
+        overflow-x: auto;
+        padding-bottom: 4px;
+        margin: 12px 0 18px;
+    }
+
+    .blc-dashboard-nav .nav-tab {
+        flex: 1 0 auto;
+        text-align: center;
+        white-space: nowrap;
+    }
+
+    .blc-link-type-select-wrapper {
+        margin-bottom: 18px;
+    }
+
+    .blc-link-type-select {
+        min-height: 32px;
+    }
+
+    .wrap .subsubsub {
+        display: none;
     }
 }
 

--- a/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
+++ b/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
@@ -1062,4 +1062,65 @@ jQuery(document).ready(function($) {
             }
         });
     });
+
+    (function setupMobileLinkTypeFilter() {
+        var $selects = $('.blc-link-type-select');
+
+        if (!$selects.length) {
+            return;
+        }
+
+        $selects.each(function() {
+            var $select = $(this);
+            var currentView = $select.data('currentView');
+            var resolvedValue = (typeof currentView === 'string' && currentView !== '') ? currentView : null;
+
+            if (typeof window.URLSearchParams !== 'undefined') {
+                try {
+                    var params = new window.URLSearchParams(window.location.search);
+                    var paramValue = params.get('link_type');
+
+                    if (paramValue !== null && paramValue !== '') {
+                        resolvedValue = paramValue;
+                    }
+                } catch (error) {
+                    // Ignored: keep fallback value.
+                }
+            }
+
+            if (!resolvedValue || !$select.find('option[value="' + resolvedValue + '"]').length) {
+                if ($select.find('option[value="all"]').length) {
+                    resolvedValue = 'all';
+                } else if ($select.find('option').length) {
+                    resolvedValue = $select.find('option').first().val();
+                }
+            }
+
+            if (resolvedValue) {
+                $select.val(resolvedValue);
+            }
+
+            $select.on('change', function() {
+                var shouldAutoSubmit = true;
+
+                if (typeof window.matchMedia === 'function') {
+                    shouldAutoSubmit = window.matchMedia('(max-width: 782px)').matches;
+                }
+
+                if (!shouldAutoSubmit) {
+                    return;
+                }
+
+                var $form = $select.closest('form');
+                if (!$form.length) {
+                    return;
+                }
+
+                var formElement = $form.get(0);
+                if (formElement && typeof formElement.submit === 'function') {
+                    formElement.submit();
+                }
+            });
+        });
+    })();
 });


### PR DESCRIPTION
## Summary
- add a mobile nav tab wrapper linking the dashboard, image report, and settings pages, plus a dropdown for link-type views
- style the new navigation and select elements to appear on small screens while hiding redundant desktop-only controls
- sync the filter select with the current URL via JavaScript and auto-submit it on mobile breakpoints

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68defbc74160832e93adaf0ba5d64805