### PR TITLE
Add dashboard navigation tabs to broken content pages

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -1,6 +1,73 @@
 /* Styles pour le plugin Liens morts detector - JLG */
 
 /* Amélioration de la lisibilité des descriptions dans les formulaires */
+.blc-admin-tabs {
+    margin: 0 0 24px;
+}
+
+.blc-admin-tabs__list {
+    display: flex;
+    gap: 8px;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+}
+
+.blc-admin-tabs__item {
+    margin: 0;
+}
+
+.blc-admin-tabs__link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px 16px;
+    border-radius: 6px;
+    border: 1px solid transparent;
+    background: #f6f7f7;
+    color: #1d2327;
+    font-weight: 500;
+    text-decoration: none;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease;
+}
+
+.blc-admin-tabs__link:hover {
+    background: #e0f0ff;
+    color: #0a4b78;
+}
+
+.blc-admin-tabs__link:focus-visible {
+    outline: 2px solid #2271b1;
+    outline-offset: 2px;
+}
+
+.blc-admin-tabs__link.is-active {
+    background: #ffffff;
+    border-color: #2271b1;
+    color: #0a4b78;
+    box-shadow: inset 0 -2px 0 #2271b1;
+}
+
+.blc-admin-tabs__link.is-active:focus-visible {
+    outline-offset: 4px;
+}
+
+@media (max-width: 782px) {
+    .blc-admin-tabs__list {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .blc-admin-tabs__link {
+        justify-content: flex-start;
+        width: 100%;
+    }
+
+    .blc-admin-tabs__link.is-active {
+        box-shadow: none;
+    }
+}
+
 .wrap form p small {
     color: #666;
 }

--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -48,6 +48,51 @@ function blc_add_admin_menu() {
 }
 
 /**
+ * Rend la navigation principale des pages du tableau de bord du plugin.
+ *
+ * @param string $active_tab Identifiant de l'onglet actif.
+ */
+function blc_render_dashboard_tabs($active_tab) {
+    $tabs = array(
+        'links'    => array(
+            'label' => __('Liens', 'liens-morts-detector-jlg'),
+            'page'  => 'blc-dashboard',
+        ),
+        'images'   => array(
+            'label' => __('Images', 'liens-morts-detector-jlg'),
+            'page'  => 'blc-images-dashboard',
+        ),
+        'settings' => array(
+            'label' => __('Réglages', 'liens-morts-detector-jlg'),
+            'page'  => 'blc-settings',
+        ),
+    );
+
+    $navigation_label = __('Navigation du tableau de bord Liens Morts', 'liens-morts-detector-jlg');
+
+    echo '<nav class="blc-admin-tabs" aria-label="' . esc_attr($navigation_label) . '"><ul class="blc-admin-tabs__list">';
+
+    foreach ($tabs as $tab_key => $tab) {
+        $is_active      = ($tab_key === $active_tab);
+        $aria_current   = $is_active ? ' aria-current="page"' : '';
+        $active_class   = $is_active ? ' is-active' : '';
+        $tab_url        = function_exists('admin_url')
+            ? admin_url('admin.php?page=' . $tab['page'])
+            : 'admin.php?page=' . $tab['page'];
+        $link_attributes = sprintf(
+            ' class="blc-admin-tabs__link%s" href="%s"%s',
+            esc_attr($active_class),
+            esc_url($tab_url),
+            $aria_current
+        );
+
+        echo '<li class="blc-admin-tabs__item"><a' . $link_attributes . '>' . esc_html($tab['label']) . '</a></li>';
+    }
+
+    echo '</ul></nav>';
+}
+
+/**
  * Affiche la modale utilisée pour l'édition et la suppression rapides.
  *
  * Cette modale est rendue une seule fois puis réutilisée via JavaScript pour
@@ -272,6 +317,7 @@ function blc_dashboard_links_page() {
 
     ?>
     <div class="wrap">
+        <?php blc_render_dashboard_tabs('links'); ?>
         <h1><?php esc_html_e('Rapport des Liens Cassés', 'liens-morts-detector-jlg'); ?></h1>
         <div class="blc-stats-box">
             <div class="blc-stat">
@@ -503,6 +549,7 @@ function blc_dashboard_images_page() {
     $list_table->prepare_items();
     ?>
     <div class="wrap">
+        <?php blc_render_dashboard_tabs('images'); ?>
         <h1><?php esc_html_e('Rapport des Images Cassées', 'liens-morts-detector-jlg'); ?></h1>
         <div class="blc-stats-box">
              <div class="blc-stat">


### PR DESCRIPTION
## Summary
- add a reusable helper to render dashboard navigation tabs with aria-current states
- display the navigation tabs on the broken links and broken images admin pages
- style the tabs for accessibility, hover/focus, and responsive stacking on mobile

## Testing
- php -l liens-morts-detector-jlg/includes/blc-admin-pages.php

------
https://chatgpt.com/codex/tasks/task_e_68df967b14d4832eb6854ca84cf4fd21