### PR TITLE
Remove presentational role from action modal container

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -64,7 +64,7 @@ function blc_render_action_modal() {
 
     $rendered = true;
     ?>
-    <div id="blc-modal" class="blc-modal" role="presentation" aria-hidden="true">
+    <div id="blc-modal" class="blc-modal" aria-hidden="true">
         <div class="blc-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="blc-modal-title">
             <button type="button" class="blc-modal__close" aria-label="<?php echo esc_attr__('Fermer la fenêtre modale', 'liens-morts-detector-jlg'); ?>">
                 <span aria-hidden="true">&times;</span>


### PR DESCRIPTION
## Summary
- remove the presentational role from the action modal wrapper so that assistive technologies can identify the dialog context through the inner element

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68df967e4d48832e851618df925bbff7