### PR TITLE
Add localized close text for context modal

### DIFF
--- a/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
+++ b/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
@@ -12,6 +12,7 @@ jQuery(document).ready(function($) {
         unlinkModalTitle: 'Supprimer le lien',
         unlinkModalConfirm: 'Supprimer',
         cancelButton: 'Annuler',
+        closeButton: 'Fermer',
         closeLabel: 'Fermer la fenêtre modale',
         emptyUrlMessage: 'Veuillez saisir une URL.',
         invalidUrlMessage: 'Veuillez saisir une URL valide.',
@@ -370,6 +371,7 @@ jQuery(document).ready(function($) {
             isOpen: false,
             onConfirm: null,
             showInput: true,
+            showCancel: true,
             isSubmitting: false
         };
 
@@ -461,6 +463,7 @@ jQuery(document).ready(function($) {
             state.isOpen = false;
             state.onConfirm = null;
             state.showInput = true;
+            state.showCancel = true;
 
             $modal.removeClass('is-open').attr('aria-hidden', 'true');
             $('body').removeClass('blc-modal-open');
@@ -501,6 +504,7 @@ jQuery(document).ready(function($) {
 
             state.onConfirm = typeof options.onConfirm === 'function' ? options.onConfirm : null;
             state.showInput = options.showInput !== false;
+            state.showCancel = options.showCancel !== false;
 
             lastFocusedElement = document.activeElement;
 
@@ -527,7 +531,14 @@ jQuery(document).ready(function($) {
             }
             $confirm.text(confirmText || messages.editModalConfirm || 'Confirmer');
 
-            $cancel.text(options.cancelText || messages.cancelButton || 'Annuler');
+            var cancelText = options.cancelText || messages.cancelButton || 'Annuler';
+            $cancel.text(cancelText);
+
+            if (state.showCancel) {
+                $cancel.show().prop('hidden', false).removeAttr('hidden').removeAttr('aria-hidden');
+            } else {
+                $cancel.hide().prop('hidden', true).attr('hidden', 'hidden').attr('aria-hidden', 'true');
+            }
             $close.attr('aria-label', options.closeLabel || messages.closeLabel || 'Fermer');
 
             clearError();
@@ -1154,8 +1165,8 @@ jQuery(document).ready(function($) {
             title: messages.contextModalTitle || '',
             message: '',
             showInput: false,
-            confirmText: messages.cancelButton || 'Fermer',
-            cancelText: messages.cancelButton || 'Fermer',
+            showCancel: false,
+            confirmText: messages.closeButton || messages.cancelButton || 'Fermer',
             closeLabel: messages.closeLabel,
             context: contextExcerpt,
             contextHtml: contextHtml,

--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -169,6 +169,7 @@ function blc_enqueue_admin_assets($hook) {
             'unlinkModalTitle'   => __('Supprimer le lien', 'liens-morts-detector-jlg'),
             'unlinkModalConfirm' => __('Supprimer', 'liens-morts-detector-jlg'),
             'cancelButton'       => __('Annuler', 'liens-morts-detector-jlg'),
+            'closeButton'        => __('Fermer', 'liens-morts-detector-jlg'),
             'closeLabel'         => __('Fermer la fenêtre modale', 'liens-morts-detector-jlg'),
             'emptyUrlMessage'    => __('Veuillez saisir une URL.', 'liens-morts-detector-jlg'),
             'invalidUrlMessage'  => __('Veuillez saisir une URL valide.', 'liens-morts-detector-jlg'),


### PR DESCRIPTION
## Summary
- add a dedicated close button label to the admin modal defaults and localization
- allow the modal helper to hide the cancel button when showCancel is false
- update the context view modal to rely on the close label and remove the secondary action

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfc1d3a0f0832e9f74a3655892a586