### PR TITLE
Enhance scan dashboards with image status and modal confirmations

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -105,6 +105,20 @@
     color: #50575e;
 }
 
+.blc-stat-note {
+    margin-top: 6px;
+    font-size: 12px;
+    line-height: 1.5;
+    color: #646970;
+    display: block;
+}
+
+@media (prefers-color-scheme: dark) {
+    .blc-stat-note {
+        color: #b7c0cc;
+    }
+}
+
 /* Styles pour les badges de statut HTTP */
 .blc-status {
     display: inline-flex;


### PR DESCRIPTION
## Summary
- add the dashboard tab navigation to the settings page for consistency
- introduce full image scan status tracking with manual scheduling, AJAX endpoints, and UI parity with link scans
- refactor admin JS to drive both link and image scan panels and reuse the custom confirmation modal, while styling the statistics note

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dfd0e1f10c832e94fde831de1d6afd