### PR TITLE
Improve HTTP status column accessibility

### DIFF
--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -440,6 +440,7 @@ class BLC_Links_List_Table extends WP_List_Table {
 
         $classes = ['blc-status'];
         $label = (string) $raw_status;
+        $status_description = __('Statut inconnu ou indisponible', 'liens-morts-detector-jlg');
 
         if (is_numeric($raw_status)) {
             $status_code = (int) $raw_status;
@@ -447,12 +448,19 @@ class BLC_Links_List_Table extends WP_List_Table {
 
             if ($status_code >= 200 && $status_code < 300) {
                 $classes[] = 'blc-status--2xx';
+                $status_description = __('Disponible (2xx)', 'liens-morts-detector-jlg');
             } elseif ($status_code >= 300 && $status_code < 400) {
                 $classes[] = 'blc-status--3xx';
+                $status_description = __('Redirection (3xx)', 'liens-morts-detector-jlg');
             } elseif ($status_code >= 400 && $status_code < 500) {
                 $classes[] = 'blc-status--4xx';
+                $status_description = __('Erreur client (4xx)', 'liens-morts-detector-jlg');
             } elseif ($status_code >= 500 && $status_code < 600) {
                 $classes[] = 'blc-status--5xx';
+                $status_description = __('Erreur serveur (5xx)', 'liens-morts-detector-jlg');
+            } elseif ($status_code >= 100 && $status_code < 200) {
+                $classes[] = 'blc-status--1xx';
+                $status_description = __('Réponse informative (1xx)', 'liens-morts-detector-jlg');
             } else {
                 $classes[] = 'blc-status--unknown';
             }
@@ -477,9 +485,10 @@ class BLC_Links_List_Table extends WP_List_Table {
         $class_attribute = implode(' ', array_filter(array_unique($sanitized_classes)));
 
         return sprintf(
-            '<span class="%s">%s</span>',
+            '<span class="%1$s" aria-label="%3$s" title="%3$s">%2$s</span>',
             esc_attr($class_attribute),
-            esc_html($label)
+            esc_html($label),
+            esc_attr($status_description)
         );
     }
 

--- a/liens-morts-detector-jlg/languages/liens-morts-detector-jlg.pot
+++ b/liens-morts-detector-jlg/languages/liens-morts-detector-jlg.pot
@@ -261,3 +261,7 @@ msgstr ""
 #: includes/blc-cron.php:26
 msgid "Une fois par mois"
 msgstr ""
+
+#: includes/class-blc-links-list-table.php:462
+msgid "Réponse informative (1xx)"
+msgstr ""

--- a/tests/AdminListTablesTest.php
+++ b/tests/AdminListTablesTest.php
@@ -179,7 +179,7 @@ class AdminListTablesTest extends TestCase
             'url'             => 'https://example.com',
         ];
 
-        $this->assertSame('<span class="blc-status blc-status--4xx blc-status--410">410</span>', $table->renderHttpStatus($item));
+        $this->assertSame('<span class="blc-status blc-status--4xx blc-status--410" aria-label="Erreur client (4xx)" title="Erreur client (4xx)">410</span>', $table->renderHttpStatus($item));
         $this->assertSame('1970-01-01 00:00', $table->renderLastChecked($item));
 
         $empty = [
@@ -191,6 +191,11 @@ class AdminListTablesTest extends TestCase
         ];
 
         $this->assertSame('—', $table->renderHttpStatus($empty));
+
+        $unknown = $item;
+        $unknown['http_status'] = 999;
+
+        $this->assertSame('<span class="blc-status blc-status--unknown blc-status--999" aria-label="Statut inconnu ou indisponible" title="Statut inconnu ou indisponible">999</span>', $table->renderHttpStatus($unknown));
         $this->assertSame('—', $table->renderLastChecked($empty));
     }
 


### PR DESCRIPTION
## Summary
- add localized HTTP status range descriptions and expose them via aria-label/title attributes in the links list table
- cover the new rendering in the admin list table test and document the new translation string

## Testing
- ./vendor/bin/phpunit --filter test_links_columns_display_status_and_timestamp tests/AdminListTablesTest.php

------
https://chatgpt.com/codex/tasks/task_e_68dff823e090832ea5ddb0efbe399911