### PR TITLE
Enhance dashboard stats cards and filter persistence

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -86,22 +86,85 @@
     margin-bottom: 20px;
     border-left: 4px solid #72aee6; /* Couleur bleue standard de WordPress */
 }
+
 .blc-stat {
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    flex-grow: 1;
+    flex: 1 1 180px;
     text-align: center;
+    gap: 8px;
+    padding: 18px;
+    border: 1px solid #dcdcde;
+    border-radius: 6px;
+    background-color: #f6f7f7;
+    color: #1d2327;
+    text-decoration: none;
+    transition: background-color 0.2s ease, color 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    cursor: pointer;
 }
+
+.blc-stat:hover,
+.blc-stat:focus-visible {
+    background-color: #f0f6fc;
+    border-color: #2271b1;
+    color: #0a4b78;
+    box-shadow: 0 0 0 1px #2271b1 inset;
+}
+
+.blc-stat:focus-visible {
+    outline: 2px solid #2271b1;
+    outline-offset: 2px;
+}
+
+.blc-stat:hover .blc-stat-label,
+.blc-stat:focus-visible .blc-stat-label {
+    text-decoration: underline;
+}
+
 .blc-stat-value {
-    font-size: 2.5em;
+    font-size: 2.2em;
     font-weight: 600;
     line-height: 1.2;
-    color: #1d2327;
+    color: inherit;
 }
+
 .blc-stat-label {
     font-size: 1em;
+    color: inherit;
+}
+
+.blc-meta-box {
+    display: flex;
+    gap: 20px;
+    flex-wrap: wrap;
+    background-color: #fff;
+    border: 1px solid #c3c4c7;
+    padding: 20px;
+    margin-bottom: 20px;
+    border-left: 4px solid #dcdcde;
+}
+
+.blc-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    flex: 1 1 180px;
+    text-align: center;
+    gap: 6px;
+}
+
+.blc-meta-value {
+    font-size: 1.6em;
+    font-weight: 600;
+    line-height: 1.3;
+    color: #1d2327;
+}
+
+.blc-meta-label {
+    font-size: 0.95em;
     color: #50575e;
 }
 
@@ -113,7 +176,39 @@
     display: block;
 }
 
+@media (prefers-reduced-motion: reduce) {
+    .blc-stat {
+        transition: none;
+    }
+}
+
 @media (prefers-color-scheme: dark) {
+    .blc-stat {
+        background-color: #1f1f1f;
+        border-color: #3c434a;
+        color: #f0f0f1;
+    }
+
+    .blc-stat:hover,
+    .blc-stat:focus-visible {
+        background-color: #30363d;
+        border-color: #72aee6;
+        color: #cbe5ff;
+    }
+
+    .blc-meta-box {
+        background-color: #1d2327;
+        border-color: #3c434a;
+    }
+
+    .blc-meta-value {
+        color: #f0f0f1;
+    }
+
+    .blc-meta-label {
+        color: #d0d3d7;
+    }
+
     .blc-stat-note {
         color: #b7c0cc;
     }

--- a/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
+++ b/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
@@ -1828,4 +1828,102 @@ jQuery(document).ready(function($) {
             }
         });
     });
+
+(function setupDashboardFilterPersistence() {
+    var STORAGE_KEY = 'blcDashboardLinkType';
+    var $dashboard = $('.blc-dashboard-links-page');
+
+    if (!$dashboard.length) {
+        return;
+    }
+
+    var storageAvailable = false;
+    try {
+        var testKey = STORAGE_KEY + '_test';
+        window.localStorage.setItem(testKey, '1');
+        window.localStorage.removeItem(testKey);
+        storageAvailable = true;
+    } catch (error) {
+        storageAvailable = false;
+    }
+
+    if (!storageAvailable) {
+        return;
+    }
+
+    var params;
+    try {
+        params = new URLSearchParams(window.location.search);
+    } catch (error) {
+        return;
+    }
+
+    if (params.get('page') !== 'blc-dashboard') {
+        return;
+    }
+
+    var storedType = window.localStorage.getItem(STORAGE_KEY) || '';
+    var hasLinkType = params.has('link_type') && params.get('link_type') !== null;
+
+    if (!hasLinkType) {
+        if (storedType && storedType !== 'all') {
+            params.set('link_type', storedType);
+            var redirectUrl = window.location.pathname + '?' + params.toString();
+            if (window.location.hash) {
+                redirectUrl += window.location.hash;
+            }
+            window.location.replace(redirectUrl);
+            return;
+        }
+        storedType = 'all';
+    } else {
+        storedType = params.get('link_type') || '';
+        if (!storedType) {
+            storedType = 'all';
+        }
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, storedType);
+
+    $dashboard.on('click', '.blc-stats-box a[data-link-type]', function() {
+        var type = $(this).data('link-type');
+        if (typeof type === 'undefined' || type === null || type === '') {
+            type = 'all';
+        }
+        window.localStorage.setItem(STORAGE_KEY, String(type));
+    });
+
+    $(document).on('click', 'a[href*="page=blc-dashboard"]', function() {
+        var href = $(this).attr('href');
+        if (!href) {
+            return;
+        }
+
+        var linkType = null;
+        try {
+            var url = new URL(href, window.location.origin);
+            if (url.searchParams.get('page') !== 'blc-dashboard') {
+                return;
+            }
+            if (url.searchParams.has('link_type')) {
+                linkType = url.searchParams.get('link_type') || '';
+            } else {
+                linkType = 'all';
+            }
+        } catch (error) {
+            return;
+        }
+
+        if (linkType === null) {
+            return;
+        }
+
+        if (!linkType) {
+            linkType = 'all';
+        }
+
+        window.localStorage.setItem(STORAGE_KEY, linkType);
+    });
+})();
+
 });


### PR DESCRIPTION
## Summary
- reuse the aggregated link status counts to render new dashboard cards for totals, 404/410, 5xx, redirects, and links to recheck with translated labels and deep links
- refresh the dashboard layout and styles to provide hover/focus states and move ancillary metrics into a meta panel
- persist the last selected dashboard filter via localStorage so it reopens with the same view

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68dff8230220832e9a184acb6e1dec64