### PR TITLE
Refine dashboard link statistics

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -106,11 +106,16 @@
 }
 
 .blc-stat:hover,
+.blc-stat:focus,
 .blc-stat:focus-visible {
     background-color: #f0f6fc;
     border-color: #2271b1;
     color: #0a4b78;
     box-shadow: 0 0 0 1px #2271b1 inset;
+}
+
+.blc-stat:focus {
+    outline: none;
 }
 
 .blc-stat:focus-visible {
@@ -119,7 +124,11 @@
 }
 
 .blc-stat:hover .blc-stat-label,
-.blc-stat:focus-visible .blc-stat-label {
+.blc-stat:focus .blc-stat-label,
+.blc-stat:focus-visible .blc-stat-label,
+.blc-stat:hover .blc-stat-value,
+.blc-stat:focus .blc-stat-value,
+.blc-stat:focus-visible .blc-stat-value {
     text-decoration: underline;
 }
 


### PR DESCRIPTION
## Summary
- normalise the broken-link status counts coming from the list table query before exposing them in dashboard stat cards
- generate the card payloads from a single blueprint so each tile links to the correct filtered view with translated labels
- improve hover and focus treatments on dashboard stat cards to satisfy WP-Admin accessibility expectations

## Testing
- php -l liens-morts-detector-jlg/includes/blc-admin-pages.php

------
https://chatgpt.com/codex/tasks/task_e_68e0349ec6d4832e8f7466ef18e7f202