### PR TITLE
Add AJAX workflow to apply detected redirects

### DIFF
--- a/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
+++ b/liens-morts-detector-jlg/includes/class-blc-links-list-table.php
@@ -600,11 +600,10 @@ class BLC_Links_List_Table extends WP_List_Table {
 
         $data_attributes = implode(' ', $data_attributes);
 
-        $edit_nonce            = wp_create_nonce('blc_edit_link_nonce');
-        $ignore_nonce          = wp_create_nonce('blc_ignore_link_nonce');
-        $unlink_nonce          = wp_create_nonce('blc_unlink_nonce');
-        $recheck_nonce         = wp_create_nonce('blc_recheck_link_nonce');
-        $apply_redirect_nonce  = wp_create_nonce('blc_apply_detected_redirect_nonce');
+        $edit_nonce    = wp_create_nonce('blc_edit_link_nonce');
+        $ignore_nonce  = wp_create_nonce('blc_ignore_link_nonce');
+        $unlink_nonce  = wp_create_nonce('blc_unlink_nonce');
+        $recheck_nonce = wp_create_nonce('blc_recheck_link_nonce');
 
         $actions['edit_link'] = sprintf(
             '<button type="button" class="button button-small button-link blc-edit-link" %s data-nonce="%s">%s</button>',
@@ -621,10 +620,12 @@ class BLC_Links_List_Table extends WP_List_Table {
         );
 
         if ($detected_target !== '') {
+            $apply_redirect_nonce = wp_create_nonce('blc_apply_detected_redirect_nonce');
+
             $actions['apply_redirect'] = sprintf(
                 '<button type="button" class="button button-small button-link blc-apply-redirect" %s data-nonce="%s">%s</button>',
                 $data_attributes,
-                $apply_redirect_nonce,
+                esc_attr($apply_redirect_nonce),
                 esc_html__('Appliquer la redirection détectée', 'liens-morts-detector-jlg')
             );
         }
@@ -1778,5 +1779,21 @@ class BLC_Links_List_Table extends WP_List_Table {
         ];
 
         return $this->internal_url_condition_cache;
+    }
+
+    /**
+     * Render the HTML markup for a single row using the table's column definitions.
+     *
+     * @param array $item Row data to render.
+     * @return string
+     */
+    public function render_row_html(array $item) {
+        $this->_column_headers = [$this->get_columns(), [], []];
+        $this->items           = [$item];
+
+        ob_start();
+        $this->single_row($item);
+
+        return (string) ob_get_clean();
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated Apply Redirect row action with an escaped nonce when a detected target is available
- expose a reusable renderer on the links list table and helper functions to fetch a single row for AJAX refreshes
- extend the blc_apply_detected_redirect AJAX handler to return refreshed markup while keeping success messaging localized

## Testing
- php -l liens-morts-detector-jlg/includes/class-blc-links-list-table.php
- php -l liens-morts-detector-jlg/liens-morts-detector-jlg.php

------
https://chatgpt.com/codex/tasks/task_e_68e034a09474832eaf4d1d4c51a28504