### PR TITLE
Add row rendering for detected redirect updates

### DIFF
--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -1033,10 +1033,19 @@ function blc_ajax_apply_detected_redirect_callback() {
     }
 
     $response = [
-        'message'    => $result['message'] ?? __('La redirection détectée a été appliquée.', 'liens-morts-detector-jlg'),
+        'message'      => $result['message'] ?? __('La redirection détectée a été appliquée.', 'liens-morts-detector-jlg'),
         'announcement' => $result['announcement'] ?? ($result['message'] ?? ''),
-        'rowRemoved' => !empty($result['row_removed']),
+        'rowRemoved'   => !empty($result['row_removed']),
     ];
+
+    if (empty($result['row_removed']) && class_exists('BLC_Links_List_Table')) {
+        $list_table = new BLC_Links_List_Table();
+        $row_html   = $list_table->get_single_row_html($row_id);
+
+        if ($row_html !== '') {
+            $response['rowHtml'] = $row_html;
+        }
+    }
 
     if (!empty($result['purged'])) {
         $response['purged'] = true;


### PR DESCRIPTION
## Summary
- add a helper on the links list table to render refreshed HTML for a single row
- include the refreshed row markup in the detected redirect AJAX response when a row remains

## Testing
- npm test --silent

------
https://chatgpt.com/codex/tasks/task_e_68e03b9fc014832ebb2d1eee27bbf321