### PR TITLE
Highlight active dashboard stats card

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -105,6 +105,18 @@
     cursor: pointer;
 }
 
+.blc-stat.is-active {
+    background-color: #f0f6fc;
+    border-color: #2271b1;
+    color: #0a4b78;
+    box-shadow: 0 0 0 1px #2271b1 inset;
+}
+
+.blc-stat.is-active .blc-stat-label,
+.blc-stat.is-active .blc-stat-value {
+    text-decoration: none;
+}
+
 .blc-stat:hover,
 .blc-stat:focus,
 .blc-stat:focus-visible {
@@ -196,6 +208,13 @@
         background-color: #1f1f1f;
         border-color: #3c434a;
         color: #f0f0f1;
+    }
+
+    .blc-stat.is-active {
+        background-color: #233142;
+        border-color: #72aee6;
+        color: #cbe5ff;
+        box-shadow: 0 0 0 1px #72aee6 inset;
     }
 
     .blc-stat:hover,

--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -552,6 +552,14 @@ function blc_dashboard_links_page() {
     $list_table = new BLC_Links_List_Table();
     $status_counts = $list_table->get_status_counts();
 
+    $current_link_type = 'all';
+    if (isset($_GET['link_type'])) {
+        $link_type_param = sanitize_key(wp_unslash($_GET['link_type']));
+        if ($link_type_param !== '') {
+            $current_link_type = $link_type_param;
+        }
+    }
+
     $status_counts = array_map(
         'intval',
         wp_parse_args(
@@ -655,12 +663,20 @@ function blc_dashboard_links_page() {
                     $card['label'],
                     $card['value']
                 );
+                $is_active_card = ($link_type === 'all' && $current_link_type === 'all')
+                    || ($link_type !== 'all' && $current_link_type === $link_type);
+                $card_classes = array(
+                    'blc-stat',
+                    'blc-stat--' . $card['slug'],
+                    $is_active_card ? 'is-active' : '',
+                );
                 ?>
                 <a
-                    class="blc-stat blc-stat--<?php echo esc_attr($card['slug']); ?>"
+                    class="<?php echo esc_attr(implode(' ', array_filter(array_map('sanitize_html_class', $card_classes)))); ?>"
                     href="<?php echo esc_url($card_url); ?>"
                     data-link-type="<?php echo esc_attr($link_type); ?>"
                     aria-label="<?php echo esc_attr($aria_label); ?>"
+                    <?php echo $is_active_card ? ' aria-current="page"' : ''; ?>
                 >
                     <span class="blc-stat-value"><?php echo esc_html($card['value']); ?></span>
                     <span class="blc-stat-label"><?php echo esc_html($card['label']); ?></span>


### PR DESCRIPTION
## Summary
- detect the currently selected broken-link filter and add an active class/aria-current on the corresponding dashboard stat card
- style the active stat card for both default and dark color schemes so it remains distinguishable from hover/focus states

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e03b9e529c832e8ed2333db099b8fc