### PR TITLE
Fix activation fallback schedule handling

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-activation.php
+++ b/liens-morts-detector-jlg/includes/blc-activation.php
@@ -426,8 +426,17 @@ function blc_activate_site() {
                 update_option('blc_activation_schedule_failure', $notice_payload);
             }
 
-            $fallback_frequency = 'daily';
-            if ($frequency !== $fallback_frequency && isset($schedules[$fallback_frequency])) {
+            $fallback_frequency   = 'daily';
+            $requested_frequency = isset($schedule_result['schedule']) && $schedule_result['schedule'] !== ''
+                ? $schedule_result['schedule']
+                : $frequency_option;
+            if (function_exists('wp_get_schedules')) {
+                $schedules = wp_get_schedules();
+            } else {
+                $schedules = array();
+            }
+
+            if ($requested_frequency !== $fallback_frequency && isset($schedules[$fallback_frequency])) {
                 $fallback_timestamp = time() + (defined('HOUR_IN_SECONDS') ? (int) HOUR_IN_SECONDS : 3600);
                 $fallback = wp_schedule_event($fallback_timestamp, $fallback_frequency, 'blc_check_links');
 


### PR DESCRIPTION
## Summary
- ensure the activation fallback schedule reuses the requested frequency and freshly fetched cron schedules
- add unit coverage that exercises the activation fallback path when schedule registration fails

## Testing
- vendor/bin/phpunit --filter test_activation_schedules_daily_fallback_when_initial_schedule_fails tests/BlcSettingsPageTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e0ea0da014832eb646a7ae9adddc0d