### PR TITLE
Add WP-CLI commands for synchronous scans

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ Liens Morts Detector est une extension WordPress qui détecte les liens et image
 - Des réglages avancés permettent d’exclure certains domaines, de limiter l’analyse à des plages horaires et d’activer un mode debug pour le suivi.
 - L’analyse des images distantes (CDN, sous-domaines médias) peut être activée dans les réglages. Cette vérification reste basée sur les fichiers présents dans `wp-content/uploads` et peut rallonger la durée du scan ou consommer davantage de quotas côté CDN.
 
+## Commandes WP-CLI
+- `wp broken-links scan links` lance immédiatement un lot de vérification des liens. Ajouter `--full` force une réindexation complète, et `--bypass-rest-window` ignore la plage de repos configurée.
+- `wp broken-links scan images` exécute le scanner d’images de façon synchrone. Le flag `--full` est accepté pour homogénéité (le mode complet est déjà l’option par défaut).
+- Les commandes affichent la progression (lots et éléments traités) ainsi que les messages d’état renvoyés par le scanner. Elles retournent un code de sortie non nul en cas d’échec, ce qui permet une intégration directe dans vos scripts d’automatisation ou jobs de supervision.
+
 ## Hooks disponibles
 ### `blc_cron_schedule_definitions`
 Permet d’ajouter, modifier ou supprimer des intervalles WP‑Cron proposés par défaut (heures, jours, semaines…). Chaque entrée doit fournir un identifiant unique ainsi qu’un intervalle en secondes.

--- a/liens-morts-detector-jlg/includes/blc-cli.php
+++ b/liens-morts-detector-jlg/includes/blc-cli.php
@@ -1,0 +1,265 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!defined('WP_CLI') || !WP_CLI || !class_exists('WP_CLI_Command')) {
+    return;
+}
+
+class BLC_Scan_CLI_Command extends WP_CLI_Command
+{
+    /**
+     * Launch a link scan synchronously from the command line.
+     *
+     * ## OPTIONS
+     *
+     * [--full]
+     * : Execute a full scan instead of the incremental mode.
+     *
+     * [--bypass-rest-window]
+     * : Ignore the configured rest window when running the scan.
+     *
+     * ## EXAMPLES
+     *
+     *     wp broken-links scan links --full
+     *
+     * @param array<int, string> $args Positional arguments.
+     * @param array<string, mixed> $assoc_args Associative arguments.
+     *
+     * @return void
+     */
+    public function links($args, $assoc_args)
+    {
+        $is_full_scan = (bool) \WP_CLI\Utils\get_flag_value($assoc_args, 'full', false);
+        $bypass_rest_window = (bool) \WP_CLI\Utils\get_flag_value($assoc_args, 'bypass-rest-window', true);
+
+        $this->run_link_scan($is_full_scan, $bypass_rest_window);
+    }
+
+    /**
+     * Launch an image scan synchronously from the command line.
+     *
+     * ## OPTIONS
+     *
+     * [--full]
+     * : Execute a full scan (default behaviour).
+     *
+     * ## EXAMPLES
+     *
+     *     wp broken-links scan images
+     *
+     * @param array<int, string> $args Positional arguments.
+     * @param array<string, mixed> $assoc_args Associative arguments.
+     *
+     * @return void
+     */
+    public function images($args, $assoc_args)
+    {
+        $is_full_scan = (bool) \WP_CLI\Utils\get_flag_value($assoc_args, 'full', true);
+
+        $this->run_image_scan($is_full_scan);
+    }
+
+    private function run_link_scan(bool $is_full_scan, bool $bypass_rest_window): void
+    {
+        $remote_client = blc_make_remote_request_client();
+        $queue = blc_make_scan_queue($remote_client);
+        $controller = blc_make_link_scan_controller($queue);
+
+        $this->process_batches(
+            static function (array $task) use ($controller) {
+                $batch = (int) ($task['args'][0] ?? 0);
+                $is_full = (bool) ($task['args'][1] ?? false);
+                $bypass = (bool) ($task['args'][2] ?? false);
+
+                \WP_CLI::log(sprintf('→ Lancement du lot de liens #%d (scan complet : %s)…', $batch, $is_full ? 'oui' : 'non'));
+
+                $result = $controller->runBatch($batch, $is_full, $bypass);
+                if (is_wp_error($result)) {
+                    \WP_CLI::error($result->get_error_message());
+                }
+
+                $status = blc_get_link_scan_status();
+                $this->display_status('liens', $status);
+
+                return $status;
+            },
+            [
+                'hook'  => 'blc_check_batch',
+                'args'  => [0, $is_full_scan, $bypass_rest_window],
+                'delay' => 0,
+            ],
+            ['blc_check_batch']
+        );
+
+        $final_status = blc_get_link_scan_status();
+        if ($final_status['state'] !== 'completed') {
+            $message = $final_status['last_error'] ?: $final_status['message'] ?: __('Analyse des liens interrompue.', 'liens-morts-detector-jlg');
+            \WP_CLI::error($message);
+        }
+
+        \WP_CLI::success('Analyse des liens terminée.');
+    }
+
+    private function run_image_scan(bool $is_full_scan): void
+    {
+        $queue = blc_make_image_scan_queue();
+        $controller = blc_make_image_scan_controller($queue);
+
+        $this->process_batches(
+            static function (array $task) use ($controller) {
+                $batch = (int) ($task['args'][0] ?? 0);
+                $is_full = (bool) ($task['args'][1] ?? true);
+
+                \WP_CLI::log(sprintf('→ Lancement du lot d\'images #%d…', $batch));
+
+                $result = $controller->run($batch, $is_full);
+                if (is_wp_error($result)) {
+                    \WP_CLI::error($result->get_error_message());
+                }
+
+                $status = blc_get_image_scan_status();
+                $this->display_status('images', $status);
+
+                return $status;
+            },
+            [
+                'hook'  => 'blc_check_image_batch',
+                'args'  => [0, $is_full_scan],
+                'delay' => 0,
+            ],
+            ['blc_check_image_batch']
+        );
+
+        $final_status = blc_get_image_scan_status();
+        if ($final_status['state'] !== 'completed') {
+            $message = $final_status['last_error'] ?: $final_status['message'] ?: __('Analyse des images interrompue.', 'liens-morts-detector-jlg');
+            \WP_CLI::error($message);
+        }
+
+        \WP_CLI::success('Analyse des images terminée.');
+    }
+
+    /**
+     * @param callable(array):array<string, mixed> $runner
+     * @param array<string, mixed>                 $initial_task
+     * @param string[]                              $allowed_hooks
+     *
+     * @return void
+     */
+    private function process_batches(callable $runner, array $initial_task, array $allowed_hooks): void
+    {
+        $scheduled_events = [];
+        $filter = static function ($pre, $event) use (&$scheduled_events, $allowed_hooks) {
+            if (!is_array($event) || empty($event['hook']) || !in_array($event['hook'], $allowed_hooks, true)) {
+                return $pre;
+            }
+
+            $scheduled_events[] = $event;
+
+            return true;
+        };
+
+        add_filter('pre_schedule_event', $filter, 10, 2);
+
+        $queue = [$initial_task];
+        $seen = [];
+        $iterations = 0;
+
+        try {
+            while (!empty($queue)) {
+                if (++$iterations > 1000) {
+                    \WP_CLI::error('Nombre maximal d\'itérations atteint pendant le scan.');
+                }
+
+                $task = array_shift($queue);
+                $delay = isset($task['delay']) ? (int) $task['delay'] : 0;
+
+                $signature = $task['hook'] . '|' . wp_json_encode($task['args']);
+                if (isset($seen[$signature]) && $delay === 0) {
+                    continue;
+                }
+                $seen[$signature] = true;
+
+                if ($delay > 0) {
+                    \WP_CLI::log(sprintf('⏳ Pause de %d s avant le prochain lot…', $delay));
+                    sleep($delay);
+                }
+
+                $status = $runner($task);
+
+                $state = isset($status['state']) ? (string) $status['state'] : 'idle';
+                if (in_array($state, ['completed', 'failed', 'cancelled'], true)) {
+                    break;
+                }
+
+                if ($scheduled_events === []) {
+                    \WP_CLI::warning("Aucun lot suivant n'a été planifié. Le scan risque de rester incomplet.");
+                    break;
+                }
+
+                foreach ($scheduled_events as $event) {
+                    $event_args = isset($event['args']) && is_array($event['args']) ? $event['args'] : [];
+                    $queue[] = [
+                        'hook'  => (string) $event['hook'],
+                        'args'  => $event_args,
+                        'delay' => max(0, (int) $event['timestamp'] - time()),
+                    ];
+                }
+
+                $scheduled_events = [];
+            }
+        } finally {
+            remove_filter('pre_schedule_event', $filter, 10);
+
+            if (function_exists('wp_clear_scheduled_hook')) {
+                foreach ($allowed_hooks as $hook) {
+                    wp_clear_scheduled_hook($hook);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param string                   $dataset
+     * @param array<string, mixed>     $status
+     *
+     * @return void
+     */
+    private function display_status(string $dataset, array $status): void
+    {
+        $state = strtoupper((string) ($status['state'] ?? ''));
+        $message = isset($status['message']) ? trim((string) $status['message']) : '';
+
+        $batch_progress = '';
+        $total_batches = (int) ($status['total_batches'] ?? 0);
+        $processed_batches = (int) ($status['processed_batches'] ?? 0);
+        if ($total_batches > 0) {
+            $batch_progress = sprintf('%d/%d lots', $processed_batches, $total_batches);
+        }
+
+        $item_progress = '';
+        $total_items = (int) ($status['total_items'] ?? 0);
+        $processed_items = (int) ($status['processed_items'] ?? 0);
+        if ($total_items > 0) {
+            $item_progress = sprintf('%d/%d éléments', $processed_items, $total_items);
+        } elseif ($processed_items > 0) {
+            $item_progress = sprintf('%d éléments traités', $processed_items);
+        }
+
+        $parts = array_filter([$batch_progress, $item_progress]);
+        if ($parts !== []) {
+            \WP_CLI::log(sprintf('[%s] Progression %s : %s', $state, $dataset, implode(', ', $parts)));
+        } else {
+            \WP_CLI::log(sprintf('[%s] Progression %s…', $state, $dataset));
+        }
+
+        if ($message !== '') {
+            \WP_CLI::log($message);
+        }
+    }
+}
+
+WP_CLI::add_command('broken-links scan', 'BLC_Scan_CLI_Command');

--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -58,6 +58,7 @@ require_once BLC_PLUGIN_PATH . 'includes/blc-settings-fields.php';
 require_once BLC_PLUGIN_PATH . 'includes/blc-admin-pages.php';
 require_once BLC_PLUGIN_PATH . 'includes/class-blc-links-list-table.php';
 require_once BLC_PLUGIN_PATH . 'includes/class-blc-images-list-table.php';
+require_once BLC_PLUGIN_PATH . 'includes/blc-cli.php';
 
 /**
  * Mark the cached view counters for broken links as stale so they can be recalculated.


### PR DESCRIPTION
## Summary
- add a dedicated CLI helper that exposes `wp broken-links scan links` and `wp broken-links scan images`
- wire the new helper into the plugin bootstrap so commands load when WP-CLI is available
- document the supported commands and flags in the README for automation users

## Testing
- composer install
- vendor/bin/phpunit tests *(fails: relies on WordPress functions that are not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0ee3c0c8c832e9ad310766fc6cb81