### PR TITLE
Add post type filters to scan settings

### DIFF
--- a/liens-morts-detector-jlg/includes/Scanner/ScanQueue.php
+++ b/liens-morts-detector-jlg/includes/Scanner/ScanQueue.php
@@ -331,20 +331,9 @@ class ScanQueue {
             $last_check_time = (int) get_option('blc_last_check_time', 0);
             $table_name      = $wpdb->prefix . 'blc_broken_links';
 
-            $public_post_types = get_post_types(['public' => true], 'names');
-            if (!is_array($public_post_types)) {
-                $public_post_types = [];
-            }
-            $public_post_types = array_values(array_filter(array_map('strval', $public_post_types), static function ($post_type) {
-                return $post_type !== '';
-            }));
-            if ($public_post_types === []) {
-                $public_post_types = ['post'];
-            }
-
             // Limiter la requête aux types de contenus publics (repli sur « post ») tout en conservant la pagination existante.
             $args = [
-                'post_type'      => $public_post_types,
+                'post_type'      => blc_get_scannable_post_types(),
                 'post_status'    => blc_get_scannable_post_statuses(),
                 'posts_per_page' => $batch_size,
                 'paged'          => $batch + 1,

--- a/liens-morts-detector-jlg/includes/blc-settings-fields.php
+++ b/liens-morts-detector-jlg/includes/blc-settings-fields.php
@@ -145,6 +145,16 @@ function blc_register_settings() {
 
     register_setting(
         $option_group,
+        'blc_post_types',
+        array(
+            'type'              => 'array',
+            'sanitize_callback' => 'blc_sanitize_post_types_option',
+            'default'           => array(),
+        )
+    );
+
+    register_setting(
+        $option_group,
         'blc_post_statuses',
         array(
             'type'              => 'array',
@@ -356,6 +366,14 @@ function blc_register_settings_sections() {
         __('Statuts analysés', 'liens-morts-detector-jlg'),
         '__return_false',
         $page
+    );
+
+    add_settings_field(
+        'blc_post_types',
+        __('Types de contenus à analyser', 'liens-morts-detector-jlg'),
+        'blc_render_post_types_field',
+        $page,
+        'blc_post_statuses_section'
     );
 
     add_settings_field(
@@ -985,6 +1003,83 @@ function blc_render_post_statuses_field() {
 }
 
 /**
+ * Affiche la liste des types de contenus sélectionnables.
+ *
+ * @return void
+ */
+function blc_render_post_types_field() {
+    $selected_post_types_option = get_option('blc_post_types', array());
+    if (!is_array($selected_post_types_option)) {
+        $selected_post_types_option = array($selected_post_types_option);
+    }
+
+    $selected_post_types = array();
+    foreach ($selected_post_types_option as $post_type_value) {
+        if (!is_scalar($post_type_value)) {
+            continue;
+        }
+
+        $post_type_key = sanitize_key((string) $post_type_value);
+        if ('' === $post_type_key) {
+            continue;
+        }
+
+        $selected_post_types[$post_type_key] = $post_type_key;
+    }
+
+    $fallback_post_types = get_post_types(array('public' => true), 'names');
+    if (!is_array($fallback_post_types)) {
+        $fallback_post_types = array();
+    }
+
+    $fallback_post_types = array_values(array_filter(array_map('sanitize_key', $fallback_post_types), static function ($post_type) {
+        return '' !== $post_type;
+    }));
+
+    if (array() === $fallback_post_types) {
+        $fallback_post_types = array('post');
+    }
+
+    if (array() === $selected_post_types) {
+        foreach ($fallback_post_types as $post_type_key) {
+            $selected_post_types[$post_type_key] = $post_type_key;
+        }
+    }
+
+    $post_type_objects = get_post_types(array(), 'objects');
+    if (!is_array($post_type_objects)) {
+        $post_type_objects = array();
+    }
+
+    foreach ($post_type_objects as $post_type_key => $post_type_object) {
+        $sanitized_key = sanitize_key((string) $post_type_key);
+        if ('' === $sanitized_key) {
+            continue;
+        }
+
+        $label = '';
+        if (is_object($post_type_object)) {
+            if (isset($post_type_object->labels) && is_object($post_type_object->labels) && isset($post_type_object->labels->name) && '' !== $post_type_object->labels->name) {
+                $label = (string) $post_type_object->labels->name;
+            } elseif (isset($post_type_object->label) && '' !== $post_type_object->label) {
+                $label = (string) $post_type_object->label;
+            }
+        }
+
+        if ('' === $label) {
+            $label = ucwords(str_replace(array('-', '_'), ' ', $sanitized_key));
+        }
+
+        ?>
+        <label>
+            <input type="checkbox" name="blc_post_types[]" value="<?php echo esc_attr($sanitized_key); ?>" <?php checked(isset($selected_post_types[$sanitized_key])); ?>>
+            <?php echo esc_html($label); ?>
+        </label><br>
+        <?php
+    }
+}
+
+/**
  * Affiche les options de méthode d'analyse.
  *
  * @return void
@@ -1457,6 +1552,55 @@ function blc_sanitize_scan_method_option($value) {
  */
 function blc_sanitize_remote_image_scan_option($value) {
     return (bool) $value;
+}
+
+/**
+ * Sanitize la liste des types de contenus sélectionnés.
+ *
+ * @param mixed $value Valeur brute.
+ *
+ * @return array
+ */
+function blc_sanitize_post_types_option($value) {
+    $available_post_types = get_post_types(array(), 'names');
+    if (!is_array($available_post_types)) {
+        $available_post_types = array();
+    }
+
+    $available_lookup = array();
+    foreach ($available_post_types as $post_type_name) {
+        $normalized_post_type = sanitize_key((string) $post_type_name);
+        if ('' === $normalized_post_type) {
+            continue;
+        }
+
+        $available_lookup[$normalized_post_type] = true;
+    }
+
+    $raw_post_types = $value;
+    if (!is_array($raw_post_types)) {
+        $raw_post_types = array($raw_post_types);
+    }
+
+    $selected_post_types = array();
+    foreach ($raw_post_types as $post_type_value) {
+        if (!is_scalar($post_type_value)) {
+            continue;
+        }
+
+        $post_type_key = sanitize_key((string) $post_type_value);
+        if ('' === $post_type_key) {
+            continue;
+        }
+
+        if (array() !== $available_lookup && !isset($available_lookup[$post_type_key])) {
+            continue;
+        }
+
+        $selected_post_types[$post_type_key] = $post_type_key;
+    }
+
+    return array_values($selected_post_types);
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a configurable `blc_post_types` option with UI and sanitization so administrators can pick which post types are scanned
- expose `blc_get_scannable_post_types()` and update link and image queues to reuse the helper
- extend scanner tests to cover configured post types alongside the legacy fallbacks

## Testing
- `./vendor/bin/phpunit tests/BlcScannerTest.php` *(fails: several pre-existing expectations unrelated to the new post type option)*

------
https://chatgpt.com/codex/tasks/task_e_68e12d919380832ead61fe5a4b4f67da