### PR TITLE
Add configurable batch size option for scans

### DIFF
--- a/liens-morts-detector-jlg/includes/Scanner/ScanQueue.php
+++ b/liens-morts-detector-jlg/includes/Scanner/ScanQueue.php
@@ -327,7 +327,46 @@ class ScanQueue {
                 : '';
 
             // --- 3. Récupération des données et préparation ---
-            $batch_size      = 20;
+            $batch_size_limits = function_exists('blc_get_batch_size_constraints')
+                ? blc_get_batch_size_constraints()
+                : array('min' => 5, 'max' => 100, 'default' => 20);
+
+            $batch_min = isset($batch_size_limits['min']) ? (int) $batch_size_limits['min'] : 5;
+            $batch_max = isset($batch_size_limits['max']) ? (int) $batch_size_limits['max'] : 100;
+            $batch_default = isset($batch_size_limits['default']) ? (int) $batch_size_limits['default'] : 20;
+
+            if ($batch_min <= 0) {
+                $batch_min = 1;
+            }
+
+            if ($batch_max < $batch_min) {
+                $batch_max = $batch_min;
+            }
+
+            $stored_batch_size = get_option('blc_batch_size', $batch_default);
+            $batch_size = is_scalar($stored_batch_size) ? (int) $stored_batch_size : $batch_default;
+
+            if ($batch_size < $batch_min) {
+                $batch_size = $batch_min;
+            } elseif ($batch_size > $batch_max) {
+                $batch_size = $batch_max;
+            }
+
+            $batch_size = (int) apply_filters(
+                'blc_batch_size',
+                $batch_size,
+                array(
+                    'context'      => 'link',
+                    'batch'        => (int) $batch,
+                    'is_full_scan' => (bool) $is_full_scan,
+                    'constraints'  => $batch_size_limits,
+                )
+            );
+
+            if ($batch_size < 1) {
+                $batch_size = $batch_min;
+            }
+
             $last_check_time = (int) get_option('blc_last_check_time', 0);
             $table_name      = $wpdb->prefix . 'blc_broken_links';
 


### PR DESCRIPTION
## Summary
- add a settings field that lets administrators configure the scan batch size with validation and documentation updates
- apply the configurable batch size (and new filter) when building scan queries for links and images
- extend the PHPUnit suite to cover custom batch sizes and boundary clamping

## Testing
- vendor/bin/phpunit tests/BlcScannerTest.php --filter batch_size

------
https://chatgpt.com/codex/tasks/task_e_68e12d8dc220832e8a5bcf9354a9da85