### PR TITLE
Allow configuring link scan batch size

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Liens Morts Detector est une extension WordPress qui détecte les liens et image
 - La cadence peut être ajustée via un champ combinant intervalles prédéfinis et intervalle personnalisé (slider toutes les X heures + heure de départ). Une action sur le tableau de bord permet de forcer la reprogrammation selon les réglages en cas de blocage de WP‑Cron.
 - Les liens ou images détectés comme cassés apparaissent dans une table permettant la modification rapide de l’URL ou la suppression du lien.
 - Des réglages avancés permettent d’exclure certains domaines, de limiter l’analyse à des plages horaires et d’activer un mode debug pour le suivi.
+- La taille des lots analysés peut être ajustée pour s’adapter aux capacités de l’hébergement (de manière optionnelle via l’interface ou un filtre).
 - L’analyse des images distantes (CDN, sous-domaines médias) peut être activée dans les réglages. Cette vérification reste basée sur les fichiers présents dans `wp-content/uploads` et peut rallonger la durée du scan ou consommer davantage de quotas côté CDN.
 
 ## Commandes WP-CLI
@@ -74,6 +75,19 @@ Définit le délai (en secondes) avant la reprise d’un scan suspendu pour caus
 ```php
 add_filter('blc_load_retry_delay', function (int $delay): int {
     return 600; // Reprogrammer le scan dans 10 minutes au lieu de 5.
+});
+```
+
+### `blc_link_batch_size`
+Permet de modifier dynamiquement la taille des lots utilisés par le scanner de liens. La valeur par défaut est bornée entre `5` et `200` éléments, mais ces limites peuvent également être ajustées via `blc_link_batch_size_constraints`.
+
+```php
+add_filter('blc_link_batch_size', function (int $batchSize, int $batch, bool $isFullScan): int {
+    if ($isFullScan) {
+        return 50; // Traiter plus d’éléments par lot lors d’une réindexation complète.
+    }
+
+    return $batchSize;
 });
 ```
 

--- a/liens-morts-detector-jlg/includes/Scanner/ScanQueue.php
+++ b/liens-morts-detector-jlg/includes/Scanner/ScanQueue.php
@@ -369,7 +369,10 @@ class ScanQueue {
                 : '';
 
             // --- 3. Récupération des données et préparation ---
-            $batch_size      = 20;
+            $batch_size_option = get_option('blc_batch_size', blc_get_link_batch_size_constraints()['default']);
+            $batch_size = blc_normalize_link_batch_size($batch_size_option);
+            $batch_size = apply_filters('blc_link_batch_size', $batch_size, $batch, $is_full_scan);
+            $batch_size = blc_normalize_link_batch_size($batch_size);
             $last_check_time = (int) get_option('blc_last_check_time', 0);
             $table_name      = $wpdb->prefix . 'blc_broken_links';
 

--- a/liens-morts-detector-jlg/includes/blc-utils.php
+++ b/liens-morts-detector-jlg/includes/blc-utils.php
@@ -1156,6 +1156,71 @@ function blc_get_request_timeout_constraints() {
 }
 
 /**
+ * Retrieve the constraints applied to the link scan batch size.
+ *
+ * @return array{default: int, min: int, max: int}
+ */
+function blc_get_link_batch_size_constraints() {
+    $defaults = [
+        'default' => 20,
+        'min'     => 5,
+        'max'     => 200,
+    ];
+
+    $candidates = apply_filters('blc_link_batch_size_constraints', $defaults);
+    if (!is_array($candidates)) {
+        $candidates = [];
+    }
+
+    $default = isset($candidates['default']) ? (int) $candidates['default'] : $defaults['default'];
+    $min     = isset($candidates['min']) ? (int) $candidates['min'] : $defaults['min'];
+    $max     = isset($candidates['max']) ? (int) $candidates['max'] : $defaults['max'];
+
+    if ($min > $max) {
+        $tmp = $min;
+        $min = $max;
+        $max = $tmp;
+    }
+
+    if ($default < $min) {
+        $default = $min;
+    } elseif ($default > $max) {
+        $default = $max;
+    }
+
+    return [
+        'default' => $default,
+        'min'     => $min,
+        'max'     => $max,
+    ];
+}
+
+/**
+ * Normalize the batch size used during link scans.
+ *
+ * @param mixed $value Raw batch size value.
+ *
+ * @return int
+ */
+function blc_normalize_link_batch_size($value) {
+    $constraints = blc_get_link_batch_size_constraints();
+
+    $default = isset($constraints['default']) ? (int) $constraints['default'] : 20;
+    $min     = isset($constraints['min']) ? (int) $constraints['min'] : 1;
+    $max     = isset($constraints['max']) ? (int) $constraints['max'] : max($min, $default);
+
+    $sanitized = is_scalar($value) ? (int) $value : $default;
+
+    if ($sanitized < $min) {
+        $sanitized = $min;
+    } elseif ($sanitized > $max) {
+        $sanitized = $max;
+    }
+
+    return $sanitized;
+}
+
+/**
  * Normalize a timeout option coming from a settings form.
  *
  * @param mixed $value   Raw submitted value.


### PR DESCRIPTION
## Summary
- add a settings field to control the link scan batch size with sanitization boundaries
- honor the configured batch size (or a filter override) when building scan queries
- document the new hook and cover varying batch sizes with unit tests

## Testing
- vendor/bin/phpunit --filter uses_custom_batch_size_option tests/BlcScannerTest.php
- vendor/bin/phpunit --filter enforces_batch_size_constraints tests/BlcScannerTest.php
- vendor/bin/phpunit --filter applies_batch_size_filter tests/BlcScannerTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e14926ff68832eb17b26e898df14cc