### PR TITLE
Add sortable columns and sanitize ordering for broken links table

### DIFF
--- a/tests/stubs/WP_List_Table.php
+++ b/tests/stubs/WP_List_Table.php
@@ -46,4 +46,9 @@ class WP_List_Table
     {
         // Intentionally left blank for tests.
     }
+
+    public function current_action()
+    {
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary
- expose sortable columns in the broken links list table so column headers can render sort links
- whitelist ORDER BY clauses in `prepare_items()` and honor the requested sort direction with a safe fallback
- cover the new behavior with admin list table tests and supporting stubs

## Testing
- ./vendor/bin/phpunit tests/AdminListTablesTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e1a436d89c832e92ebb9856234f8d4