### PR TITLE
Refine detected redirect modal handling

### DIFF
--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -204,6 +204,10 @@ function blc_enqueue_admin_assets($hook) {
             'applyRedirectMissingTarget' => __('Aucune redirection détectée n\'est disponible pour ce lien.', 'liens-morts-detector-jlg'),
             'applyRedirectModalTitle'   => __('Appliquer la redirection détectée', 'liens-morts-detector-jlg'),
             'applyRedirectModalConfirm' => __('Appliquer', 'liens-morts-detector-jlg'),
+            /* translators: %s: detected redirect target URL. */
+            'applyRedirectModalMessage' => __('Voulez-vous appliquer la redirection détectée vers %s ?', 'liens-morts-detector-jlg'),
+            'applyRedirectMissingModalTitle' => __('Redirection indisponible', 'liens-morts-detector-jlg'),
+            'applyRedirectMissingModalMessage' => __('Aucune redirection détectée n\'est disponible pour ce lien.', 'liens-morts-detector-jlg'),
             /* translators: %s: number of selected links. */
             'bulkApplyRedirectModalMessage' => __('Voulez-vous appliquer la redirection détectée aux %s liens sélectionnés ?', 'liens-morts-detector-jlg'),
         )


### PR DESCRIPTION
## Summary
- extend the admin modal helper with promise-based simple confirmation support
- route detected redirect actions through the shared modal, including a fallback when no target exists
- expose new localization strings and cover the new behaviour with front-end tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1a43575e8832ebc40e05339837485