### PR TITLE
Add configurable HTTP status filters for notification summaries

### DIFF
--- a/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
+++ b/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
@@ -155,6 +155,7 @@ jQuery(document).ready(function($) {
         var $webhookUrl = $('#blc_notification_webhook_url');
         var $webhookChannel = $('#blc_notification_webhook_channel');
         var $messageTemplate = $('#blc_notification_message_template');
+        var $statusFilterInputs = $('input[name="blc_notification_status_filters[]"]');
         var isSending = false;
 
         function ensureFeedbackContainer() {
@@ -253,6 +254,16 @@ jQuery(document).ready(function($) {
                 return;
             }
 
+            var statusFilters = [];
+            if ($statusFilterInputs.length) {
+                $statusFilterInputs.each(function() {
+                    var $input = $(this);
+                    if ($input.is(':checked')) {
+                        statusFilters.push(String($input.val()));
+                    }
+                });
+            }
+
             var ajaxEndpoint = config.ajaxUrl || (typeof window.ajaxurl !== 'undefined' ? window.ajaxurl : '');
             if (!ajaxEndpoint) {
                 showFeedback('error', config.errorText || '');
@@ -271,7 +282,8 @@ jQuery(document).ready(function($) {
                 dataset_types: datasetTypes,
                 webhook_url: webhookUrlValue,
                 webhook_channel: webhookChannelValue,
-                message_template: $messageTemplate.length ? $messageTemplate.val() : ''
+                message_template: $messageTemplate.length ? $messageTemplate.val() : '',
+                status_filters: statusFilters
             }).done(function(response) {
                 if (response && response.success) {
                     var message = (response.data && response.data.message) ? response.data.message : (config.successText || '');

--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -1581,6 +1581,15 @@ function blc_ajax_send_test_email() {
         $webhook_overrides['message_template'] = wp_unslash($_POST['message_template']);
     }
 
+    $status_filters_override = null;
+    if (isset($_POST['status_filters'])) {
+        $raw_filters = wp_unslash($_POST['status_filters']);
+        if (!is_array($raw_filters)) {
+            $raw_filters = ($raw_filters === '') ? array() : array($raw_filters);
+        }
+        $status_filters_override = blc_normalize_notification_status_filters($raw_filters);
+    }
+
     $webhook_settings = blc_get_notification_webhook_settings($webhook_overrides);
     $has_webhook = blc_is_webhook_notification_configured($webhook_settings);
 
@@ -1624,7 +1633,12 @@ function blc_ajax_send_test_email() {
     };
 
     foreach ($dataset_types as $dataset_type) {
-        $summary = blc_generate_scan_summary_email($dataset_type);
+        $summary_args = array();
+        if ($status_filters_override !== null) {
+            $summary_args['status_filters'] = $status_filters_override;
+        }
+
+        $summary = blc_generate_scan_summary_email($dataset_type, $summary_args);
         if ($summary === null) {
             $results[$dataset_type] = array(
                 'email'   => array('status' => $recipients === array() ? 'skipped' : 'failed'),


### PR DESCRIPTION
## Summary
- add a configurable set of HTTP status categories to the notification settings UI and persist the selection
- filter generated scan summaries (email/webhook) according to the selected statuses and reset stored trends when filters change
- include the selected status filters in test notification requests and extend PHP/JS tests to cover the new behaviour

## Testing
- ./vendor/bin/phpunit tests/BlcScanSummaryEmailTest.php
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1a4386da8832ea10768e68bb56cd4