### PR TITLE
Add global link update option with preview and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,34 @@ add_filter('blc_link_batch_size', function (int $batchSize, int $batch, bool $is
 });
 ```
 
+### `blc_link_mass_update_performed`
+Déclenché après une mise à jour globale d’un lien via l’interface d’actions rapides. Le hook transmet le résumé de l’opération
+ (`status`, `updated`, `failed`, `apply_globally`, `preview`) ainsi que la liste détaillée des contenus modifiés ou en erreur.
+Ce filtre est idéal pour enregistrer les changements dans un journal personnalisé ou déclencher des redirections automatiques.
+
+```php
+add_action('blc_link_mass_update_performed', function (array $context) {
+    foreach ($context['updated_posts'] as $postChange) {
+        error_log(sprintf(
+            'Lien mis à jour dans %s (%d) : %s → %s',
+            $postChange['post_title'],
+            $postChange['post_id'],
+            $postChange['old_url'],
+            $postChange['new_url']
+        ));
+    }
+
+    foreach ($context['failed_posts'] as $postError) {
+        error_log(sprintf(
+            'Échec de la mise à jour du lien dans %s (%d) : %s',
+            $postError['post_title'],
+            $postError['error_message'],
+            $postError['post_id']
+        ));
+    }
+});
+```
+
 ## Structure du projet
 - `liens-morts-detector-jlg.php` : point d’entrée du plugin, chargement des fichiers, hooks et actions AJAX.
 - `includes/` : planification WP‑Cron, fonctions d’activation/désactivation, scanners et pages d’administration.

--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -639,6 +639,64 @@
     display: block;
 }
 
+.blc-modal__section {
+    margin-bottom: 16px;
+}
+
+.blc-modal__section:last-of-type {
+    margin-bottom: 20px;
+}
+
+.blc-modal__section.is-hidden {
+    display: none;
+}
+
+.blc-modal__options-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+    margin-bottom: 6px;
+}
+
+.blc-modal__options-help {
+    margin: 0 0 12px;
+    color: #50575e;
+    font-size: 13px;
+}
+
+.blc-modal__preview-list {
+    margin: 8px 0 0 18px;
+    padding: 0;
+    list-style: disc;
+}
+
+.blc-modal__preview-item {
+    margin-bottom: 6px;
+}
+
+.blc-modal__preview-item:last-child {
+    margin-bottom: 0;
+}
+
+.blc-modal__preview-item.is-disabled {
+    opacity: 0.7;
+}
+
+.blc-modal__preview-note {
+    margin-top: 10px;
+    font-size: 13px;
+    color: #d63638;
+}
+
+.blc-inline-notices {
+    margin-bottom: 16px;
+}
+
+.blc-inline-notices .notice {
+    margin-top: 12px;
+}
+
 .blc-modal__field {
     margin-bottom: 20px;
 }

--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -122,10 +122,12 @@ function blc_render_action_modal() {
             <p class="blc-modal__message"></p>
             <div class="blc-modal__context" aria-live="polite"></div>
             <div class="blc-modal__error" role="alert" aria-live="assertive"></div>
+            <div class="blc-modal__options blc-modal__section is-hidden"></div>
             <div class="blc-modal__field">
                 <label for="blc-modal-url" class="blc-modal__label"></label>
                 <input type="url" id="blc-modal-url" class="blc-modal__input" placeholder="<?php echo esc_attr__('https://', 'liens-morts-detector-jlg'); ?>">
             </div>
+            <div class="blc-modal__preview blc-modal__section is-hidden" aria-live="polite"></div>
             <div class="blc-modal__actions">
                 <button type="button" class="button button-secondary blc-modal__cancel"><?php esc_html_e('Annuler', 'liens-morts-detector-jlg'); ?></button>
                 <button type="button" class="button button-primary blc-modal__confirm"><?php esc_html_e('Confirmer', 'liens-morts-detector-jlg'); ?></button>


### PR DESCRIPTION
## Summary
- add an "Apply everywhere" option to the quick edit modal with contextual preview and validation
- implement a mass-update path in `blc_perform_link_update()` that updates all matching rows, aggregates partial failures, and fires a logging hook
- surface mass-update results in the admin UI and expose the preview/update flow through AJAX

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1a9581e70832ea19663449ddb53a3