### PR TITLE
Ensure links list table sorting requests are sanitized

### DIFF
--- a/tests/AdminListTablesTest.php
+++ b/tests/AdminListTablesTest.php
@@ -227,6 +227,11 @@ class AdminListTablesTest extends TestCase
             {
                 return parent::get_sortable_columns();
             }
+
+            public function exposeSortRequest(): array
+            {
+                return $this->get_current_sort_request();
+            }
         };
 
         $sortable = $table->exposeSortableColumns();
@@ -237,6 +242,58 @@ class AdminListTablesTest extends TestCase
         $this->assertSame(['last_checked_at', false], $sortable['last_checked_at']);
         $this->assertArrayHasKey('anchor_text', $sortable);
         $this->assertSame(['anchor', false], $sortable['anchor_text']);
+
+        $this->assertSame(['orderby' => '', 'order' => 'desc'], $table->exposeSortRequest());
+    }
+
+    public function test_links_sort_request_is_validated(): void
+    {
+        $_GET['orderby'] = 'http_status';
+        $_GET['order'] = 'asc';
+
+        $table = new class() extends \BLC_Links_List_Table {
+            public function exposeSortableColumns(): array
+            {
+                return parent::get_sortable_columns();
+            }
+
+            public function exposeSortRequest(): array
+            {
+                return $this->get_current_sort_request();
+            }
+        };
+
+        $table->exposeSortableColumns();
+
+        $this->assertSame([
+            'orderby' => 'http_status',
+            'order'   => 'asc',
+        ], $table->exposeSortRequest());
+    }
+
+    public function test_links_sort_request_invalid_values_are_ignored(): void
+    {
+        $_GET['orderby'] = 'invalid_column;';
+        $_GET['order'] = 'sideways';
+
+        $table = new class() extends \BLC_Links_List_Table {
+            public function exposeSortableColumns(): array
+            {
+                return parent::get_sortable_columns();
+            }
+
+            public function exposeSortRequest(): array
+            {
+                return $this->get_current_sort_request();
+            }
+        };
+
+        $table->exposeSortableColumns();
+
+        $this->assertSame([
+            'orderby' => '',
+            'order'   => 'desc',
+        ], $table->exposeSortRequest());
     }
 
     public function test_links_prepare_items_supports_injected_data_with_pagination(): void


### PR DESCRIPTION
## Summary
- cache and sanitize sorting requests in the links list table so sortable column links expose only allowed fields
- build the ORDER BY clause from the validated request with a safe fallback ordering
- cover the new sorting scenarios in AdminListTablesTest

## Testing
- ./vendor/bin/phpunit tests/AdminListTablesTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e24e51c4ac832e96529c3fb3f0fbaf