### PR TITLE
Use modal confirmation for applying detected redirects

### DIFF
--- a/liens-morts-detector-jlg/assets/js/__tests__/blc-admin-scripts.test.js
+++ b/liens-morts-detector-jlg/assets/js/__tests__/blc-admin-scripts.test.js
@@ -267,7 +267,7 @@ describe('blc-admin-scripts modal interactions', () => {
     expect(modal.find('.blc-modal__error').text()).toBe(defaultMessages.genericError);
   });
 
-  test('applies a detected redirect after confirming the modal', () => {
+  test('applies a detected redirect after confirming the modal', async () => {
     const ajax = mockAjaxHandlers();
     const button = $('#the-list .blc-apply-redirect');
 
@@ -280,6 +280,7 @@ describe('blc-admin-scripts modal interactions', () => {
     expect(modal.find('.blc-modal__message').text()).toBe('Appliquer la redirection détectée vers https://detected.example ?');
 
     modal.find('.blc-modal__confirm').trigger('click');
+    await Promise.resolve();
     expect(modal.hasClass('is-submitting')).toBe(true);
 
     ajax.triggerSuccess({ success: true });
@@ -310,6 +311,24 @@ describe('blc-admin-scripts modal interactions', () => {
     expect(cancelButton.prop('hidden')).toBe(true);
 
     modal.find('.blc-modal__confirm').trigger('click');
+    jest.advanceTimersByTime(20);
+    await Promise.resolve();
+
+    expect(modal.hasClass('is-open')).toBe(false);
+    expect($.post).not.toHaveBeenCalled();
+  });
+
+  test('does not apply the redirect when the modal is cancelled', async () => {
+    const button = $('#the-list .blc-apply-redirect');
+
+    button.trigger('click');
+    jest.advanceTimersByTime(20);
+
+    const modal = $('#blc-modal');
+    expect(modal.hasClass('is-open')).toBe(true);
+
+    $.post.mockClear();
+    modal.find('.blc-modal__cancel').trigger('click');
     jest.advanceTimersByTime(20);
     await Promise.resolve();
 

--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -172,6 +172,8 @@ function blc_enqueue_admin_assets($hook) {
             'cancelButton'       => __('Annuler', 'liens-morts-detector-jlg'),
             'closeButton'        => __('Fermer', 'liens-morts-detector-jlg'),
             'closeLabel'         => __('Fermer la fenêtre modale', 'liens-morts-detector-jlg'),
+            'simpleConfirmModalConfirm' => __('Confirmer', 'liens-morts-detector-jlg'),
+            'simpleConfirmModalCancel'  => __('Annuler', 'liens-morts-detector-jlg'),
             'emptyUrlMessage'    => __('Veuillez saisir une URL.', 'liens-morts-detector-jlg'),
             'invalidUrlMessage'  => __('Veuillez saisir une URL valide.', 'liens-morts-detector-jlg'),
             'sameUrlMessage'     => __('La nouvelle URL doit être différente de l\'URL actuelle.', 'liens-morts-detector-jlg'),


### PR DESCRIPTION
## Summary
- extend the admin modal to support a simple confirmation mode without inputs
- reuse the modal for the apply redirect flow and feed it contextual information from the row
- add the missing localized labels and expand the Jest suite for the new confirmation behaviour

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e24e50d7a8832eb58b34a9435f107d