### PR TITLE
Generalize link scanning and update dataset types

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-activation.php
+++ b/liens-morts-detector-jlg/includes/blc-activation.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('BLC_DB_VERSION')) {
-    define('BLC_DB_VERSION', '1.10.0');
+    define('BLC_DB_VERSION', '1.11.0');
 }
 
 if (!defined('BLC_TEXT_FIELD_LENGTH')) {
@@ -81,6 +81,10 @@ function blc_maybe_upgrade_database() {
         blc_maybe_add_column($table_name, 'redirect_target_url', 'longtext NULL');
         blc_maybe_add_column($table_name, 'context_html', 'longtext NULL');
         blc_maybe_add_column($table_name, 'context_excerpt', 'text NULL');
+    }
+
+    if (!$installed_version || version_compare($installed_version, '1.11.0', '<')) {
+        blc_migrate_column_to_varchar($table_name, 'type', 32, false);
     }
 
     update_option('blc_plugin_db_version', BLC_DB_VERSION);
@@ -347,7 +351,7 @@ function blc_activate_site() {
         anchor varchar(" . BLC_TEXT_FIELD_LENGTH . ") NULL,
         post_id bigint(20) unsigned NOT NULL,
         post_title varchar(" . BLC_TEXT_FIELD_LENGTH . ") NULL,
-        type varchar(20) NOT NULL,
+        type varchar(32) NOT NULL,
         occurrence_index int(10) NULL DEFAULT NULL,
         url_host varchar(191) NULL,
         is_internal tinyint(1) NOT NULL DEFAULT 0,

--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -568,25 +568,24 @@ function blc_dashboard_links_page() {
         }
     }
 
-    $status_counts = array_map(
-        'intval',
-        wp_parse_args(
-            is_array($status_counts) ? $status_counts : array(),
-            array(
-                'active_count'        => 0,
-                'not_found_count'     => 0,
-                'server_error_count'  => 0,
-                'redirect_count'      => 0,
-                'needs_recheck_count' => 0,
-            )
-        )
-    );
+    $status_counts = is_array($status_counts) ? $status_counts : [];
+    $count_keys = [
+        'active_count'        => 0,
+        'not_found_count'     => 0,
+        'server_error_count'  => 0,
+        'redirect_count'      => 0,
+        'needs_recheck_count' => 0,
+    ];
 
-    $broken_links_count  = $status_counts['active_count'];
-    $not_found_count     = $status_counts['not_found_count'];
-    $server_error_count  = $status_counts['server_error_count'];
-    $redirect_count      = $status_counts['redirect_count'];
-    $needs_recheck_count = $status_counts['needs_recheck_count'];
+    foreach ($count_keys as $key => $default_value) {
+        $count_keys[$key] = isset($status_counts[$key]) ? (int) $status_counts[$key] : $default_value;
+    }
+
+    $broken_links_count  = $count_keys['active_count'];
+    $not_found_count     = $count_keys['not_found_count'];
+    $server_error_count  = $count_keys['server_error_count'];
+    $redirect_count      = $count_keys['redirect_count'];
+    $needs_recheck_count = $count_keys['needs_recheck_count'];
 
     $stats_card_blueprint = array(
         'all'        => array(

--- a/liens-morts-detector-jlg/includes/blc-utils.php
+++ b/liens-morts-detector-jlg/includes/blc-utils.php
@@ -1659,7 +1659,7 @@ function blc_get_dataset_row_types($dataset_type) {
     if ($normalized === 'image') {
         $types = ['image', 'remote-image'];
     } elseif ($normalized === 'link') {
-        $types = ['link'];
+        $types = ['link', 'iframe', 'script', 'stylesheet', 'form', 'css-background'];
     } elseif ($normalized === '') {
         $types = [];
     } else {

--- a/tests/BlcDashboardLinksPageTest.php
+++ b/tests/BlcDashboardLinksPageTest.php
@@ -433,6 +433,12 @@ class BlcDashboardLinksPageTest extends TestCase
         $this->assertStringContainsString("5xx <span class='count'>(1)</span>", $output);
         $this->assertStringContainsString("Redirections <span class='count'>(1)</span>", $output);
         $this->assertStringContainsString("À revérifier <span class='count'>(2)</span>", $output);
+        $this->assertStringContainsString("Liens HTML <span class='count'>(0)</span>", $output);
+        $this->assertStringContainsString("Iframes <span class='count'>(0)</span>", $output);
+        $this->assertStringContainsString("Scripts externes <span class='count'>(0)</span>", $output);
+        $this->assertStringContainsString("Balises &lt;link&gt; <span class='count'>(0)</span>", $output);
+        $this->assertStringContainsString("Formulaires <span class='count'>(0)</span>", $output);
+        $this->assertStringContainsString("Arrière-plans CSS <span class='count'>(0)</span>", $output);
     }
 
     public function test_hidden_page_field_not_rendered_for_non_scalar_request(): void
@@ -542,7 +548,9 @@ class BlcDashboardLinksPageTest extends TestCase
         $this->assertNotEmpty($matching_calls);
 
         foreach ($matching_calls as $call) {
-            $this->assertContains('link', $call['params']);
+            foreach (['link', 'iframe', 'script', 'stylesheet', 'form', 'css-background'] as $expectedType) {
+                $this->assertContains($expectedType, $call['params']);
+            }
             $this->assertContains('0000-00-00 00:00:00', $call['params']);
             $this->assertContains($expected_threshold, $call['params']);
         }

--- a/tests/Scanner/ScanQueueRunBatchTest.php
+++ b/tests/Scanner/ScanQueueRunBatchTest.php
@@ -143,11 +143,20 @@ final class ScanQueueRunBatchTest extends ScannerTestCase
         ]);
 
         $processedSources = [];
-        Functions\when('blc_process_link_nodes_from_html')->alias(function ($html, $charset, $callback) use (&$processedSources) {
+        Functions\when('blc_process_link_nodes_from_html')->alias(function ($html, $charset, $callbacks) use (&$processedSources) {
             $processedSources[] = $html;
             $index = count($processedSources);
             $href = 'https://scanned.test/' . $index;
-            $callback($href, 'Anchor ' . $index, '<a href="' . $href . '">Anchor</a>', 'Anchor ' . $index);
+
+            if (is_array($callbacks)) {
+                $link_callback = $callbacks['link'] ?? null;
+                if (is_callable($link_callback)) {
+                    $link_callback($href, 'Anchor ' . $index, '<a href="' . $href . '">Anchor</a>', 'Anchor ' . $index, 'link', []);
+                }
+            } elseif (is_callable($callbacks)) {
+                $callbacks($href, 'Anchor ' . $index, '<a href="' . $href . '">Anchor</a>', 'Anchor ' . $index, 'link', []);
+            }
+
             return true;
         });
 


### PR DESCRIPTION
## Summary
- generalize the HTML reference parser to collect iframe, script, stylesheet, form, and CSS background URLs alongside anchors
- update the scan queue to feed comments, meta, and widget HTML through the expanded callbacks and store the new row types
- widen the broken links schema/type handling, refresh list-table filtering, and extend PHPUnit/Jest coverage for the added categories

## Testing
- `vendor/bin/phpunit --bootstrap vendor/autoload.php tests` *(fails: legacy tests expect WordPress stubs such as sanitize_key to be re-definable before Patchwork loads)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e27ff5e688832e88a42e750e8b7b37