### PR TITLE
Expand scanning sources and resource filters

### DIFF
--- a/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
+++ b/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
@@ -2746,6 +2746,16 @@ jQuery(document).ready(function($) {
         return;
     }
 
+    var resourceStorageKey = 'blc_links_resource_type';
+
+    $(document).on('click', 'a[data-resource-type]', function() {
+        var resourceType = $(this).data('resource-type');
+        if (typeof resourceType === 'undefined' || resourceType === null || resourceType === '') {
+            resourceType = 'all';
+        }
+        window.localStorage.setItem(resourceStorageKey, String(resourceType));
+    });
+
     var storedType = window.localStorage.getItem(STORAGE_KEY) || '';
     var hasLinkType = params.has('link_type') && params.get('link_type') !== null;
 

--- a/liens-morts-detector-jlg/includes/blc-activation.php
+++ b/liens-morts-detector-jlg/includes/blc-activation.php
@@ -6,7 +6,7 @@ if (!defined('ABSPATH')) {
 }
 
 if (!defined('BLC_DB_VERSION')) {
-    define('BLC_DB_VERSION', '1.10.0');
+    define('BLC_DB_VERSION', '1.11.0');
 }
 
 if (!defined('BLC_TEXT_FIELD_LENGTH')) {
@@ -81,6 +81,10 @@ function blc_maybe_upgrade_database() {
         blc_maybe_add_column($table_name, 'redirect_target_url', 'longtext NULL');
         blc_maybe_add_column($table_name, 'context_html', 'longtext NULL');
         blc_maybe_add_column($table_name, 'context_excerpt', 'text NULL');
+    }
+
+    if (!$installed_version || version_compare($installed_version, '1.11.0', '<')) {
+        blc_migrate_column_to_varchar($table_name, 'type', 32, false);
     }
 
     update_option('blc_plugin_db_version', BLC_DB_VERSION);
@@ -347,7 +351,7 @@ function blc_activate_site() {
         anchor varchar(" . BLC_TEXT_FIELD_LENGTH . ") NULL,
         post_id bigint(20) unsigned NOT NULL,
         post_title varchar(" . BLC_TEXT_FIELD_LENGTH . ") NULL,
-        type varchar(20) NOT NULL,
+        type varchar(32) NOT NULL,
         occurrence_index int(10) NULL DEFAULT NULL,
         url_host varchar(191) NULL,
         is_internal tinyint(1) NOT NULL DEFAULT 0,

--- a/liens-morts-detector-jlg/includes/blc-utils.php
+++ b/liens-morts-detector-jlg/includes/blc-utils.php
@@ -1659,7 +1659,7 @@ function blc_get_dataset_row_types($dataset_type) {
     if ($normalized === 'image') {
         $types = ['image', 'remote-image'];
     } elseif ($normalized === 'link') {
-        $types = ['link'];
+        $types = ['link', 'iframe', 'script', 'link-rel', 'form', 'css-background'];
     } elseif ($normalized === '') {
         $types = [];
     } else {

--- a/tests/Scanner/ScanQueueRunBatchTest.php
+++ b/tests/Scanner/ScanQueueRunBatchTest.php
@@ -143,11 +143,35 @@ final class ScanQueueRunBatchTest extends ScannerTestCase
         ]);
 
         $processedSources = [];
-        Functions\when('blc_process_link_nodes_from_html')->alias(function ($html, $charset, $callback) use (&$processedSources) {
+        Functions\when('blc_process_link_nodes_from_html')->alias(function ($html, $charset, $callbacks) use (&$processedSources) {
             $processedSources[] = $html;
             $index = count($processedSources);
             $href = 'https://scanned.test/' . $index;
-            $callback($href, 'Anchor ' . $index, '<a href="' . $href . '">Anchor</a>', 'Anchor ' . $index);
+
+            $callback = null;
+            if (is_array($callbacks)) {
+                if (isset($callbacks['link']) && is_callable($callbacks['link'])) {
+                    $callback = $callbacks['link'];
+                } else {
+                    $first = reset($callbacks);
+                    if (is_callable($first)) {
+                        $callback = $first;
+                    }
+                }
+            } elseif (is_callable($callbacks)) {
+                $callback = $callbacks;
+            }
+
+            if (is_callable($callback)) {
+                $callback(
+                    $href,
+                    'Anchor ' . $index,
+                    '<a href="' . $href . '">Anchor</a>',
+                    'Anchor ' . $index,
+                    ['type' => 'link']
+                );
+            }
+
             return true;
         });
 


### PR DESCRIPTION
## Summary
- generalize the HTML scanner to emit callbacks for iframe/script/link/form and CSS background targets with metadata
- align ScanQueue storage, schema utilities, and admin list table filters to support the new resource types
- cover the new flows with PHPUnit and Jest updates, including resource filter persistence in the dashboard script

## Testing
- npm test
- ./vendor/bin/phpunit tests *(fails: WordPress core functions unavailable in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e27f322aa8832e9cec9ab74b5b332f