### PR TITLE
Add soft 404 regression tests and document heuristics

### DIFF
--- a/tests/Scanner/ScannerTestCase.php
+++ b/tests/Scanner/ScannerTestCase.php
@@ -336,6 +336,24 @@ abstract class ScannerTestCase extends TestCase
             return '';
         });
 
+        Functions\when('wp_kses_decode_entities')->alias(function ($value) {
+            if (!is_string($value)) {
+                $value = (string) $value;
+            }
+
+            return html_entity_decode($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+        });
+
+        Functions\when('wp_strip_all_tags')->alias(function ($text) {
+            if (!is_string($text)) {
+                $text = (string) $text;
+            }
+
+            $stripped = strip_tags($text);
+
+            return trim(preg_replace('/[\r\n\t ]+/', ' ', $stripped));
+        });
+
         if (!function_exists('sanitize_email')) {
             Functions\when('sanitize_email')->alias(function ($email) {
                 if (!is_string($email)) {


### PR DESCRIPTION
## Summary
- add PHP coverage for soft 404 detection including Requests\_Response handling
- extend front-end Jest suite with a scenario that normalises ignore pattern input
- document soft 404 heuristics, settings and related filters in the README

## Testing
- npm test -- --runTestsByPath liens-morts-detector-jlg/assets/js/__tests__/blc-admin-scripts.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2a2ba8238832e853b7b8eb4a0967b