### PR TITLE
Add soft 404 weighting settings and surface labels to JS

### DIFF
--- a/liens-morts-detector-jlg/assets/js/__tests__/blc-admin-scripts.test.js
+++ b/liens-morts-detector-jlg/assets/js/__tests__/blc-admin-scripts.test.js
@@ -100,13 +100,15 @@ describe('blc-admin-scripts modal interactions', () => {
     delete window.blcAdminMessages;
     window.blcAdminSoft404Config = {
       minLength: 10,
+      titleWeight: 1.5,
       titleIndicators: ['introuvable', 'erreur'],
       bodyIndicators: ['erreur 404', 'page introuvable'],
       ignorePatterns: ['/profil/i'],
       labels: {
         length: 'Contenu trop court',
         title: 'Titre suspect',
-        body: "Message d’erreur détecté"
+        body: "Message d’erreur détecté",
+        titleWeight: 'Pondération du titre'
       }
     };
     require(path.resolve(__dirname, '../blc-admin-scripts.js'));
@@ -219,6 +221,7 @@ describe('blc-admin-scripts modal interactions', () => {
     const config = window.blcAdmin.soft404.getConfig();
 
     expect(config.minLength).toBe(10);
+    expect(config.titleWeight).toBeCloseTo(1.5);
     expect(config.titleIndicators).toEqual(expect.arrayContaining(['introuvable', 'erreur']));
     expect(config.bodyIndicators).toEqual(expect.arrayContaining(['erreur 404', 'page introuvable']));
     expect(config.ignorePatterns).toEqual(expect.arrayContaining(['/profil/i']));

--- a/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
+++ b/liens-morts-detector-jlg/assets/js/blc-admin-scripts.js
@@ -261,18 +261,24 @@ jQuery(document).ready(function($) {
         var rawConfig = window.blcAdminSoft404Config || {};
         var normalizedConfig = {
             minLength: Number.isFinite(parseInt(rawConfig.minLength, 10)) ? parseInt(rawConfig.minLength, 10) : 0,
+            titleWeight: Number.isFinite(parseFloat(rawConfig.titleWeight)) ? parseFloat(rawConfig.titleWeight) : 0,
             titleIndicators: normalizeList(rawConfig.titleIndicators),
             bodyIndicators: normalizeList(rawConfig.bodyIndicators),
             ignorePatterns: normalizeList(rawConfig.ignorePatterns),
             labels: {
                 length: rawConfig.labels && rawConfig.labels.length ? rawConfig.labels.length : 'Contenu trop court',
                 title: rawConfig.labels && rawConfig.labels.title ? rawConfig.labels.title : 'Titre suspect',
-                body: rawConfig.labels && rawConfig.labels.body ? rawConfig.labels.body : 'Message d’erreur détecté'
+                body: rawConfig.labels && rawConfig.labels.body ? rawConfig.labels.body : 'Message d’erreur détecté',
+                titleWeight: rawConfig.labels && rawConfig.labels.titleWeight ? rawConfig.labels.titleWeight : 'Pondération du titre'
             }
         };
 
         if (!Number.isFinite(normalizedConfig.minLength) || normalizedConfig.minLength < 0) {
             normalizedConfig.minLength = 0;
+        }
+
+        if (!Number.isFinite(normalizedConfig.titleWeight) || normalizedConfig.titleWeight < 0) {
+            normalizedConfig.titleWeight = 0;
         }
 
         function detectSoft404(response) {
@@ -316,6 +322,7 @@ jQuery(document).ready(function($) {
                 title: title,
                 bodyText: bodyText,
                 minLength: normalizedConfig.minLength,
+                titleWeight: normalizedConfig.titleWeight,
                 labels: normalizedConfig.labels
             };
         }

--- a/liens-morts-detector-jlg/includes/blc-settings-fields.php
+++ b/liens-morts-detector-jlg/includes/blc-settings-fields.php
@@ -164,6 +164,16 @@ function blc_register_settings() {
 
     register_setting(
         $option_group,
+        'blc_soft_404_title_weight',
+        array(
+            'type'              => 'number',
+            'sanitize_callback' => 'blc_sanitize_soft_404_title_weight_option',
+            'default'           => 1.0,
+        )
+    );
+
+    register_setting(
+        $option_group,
         'blc_soft_404_title_indicators',
         array(
             'type'              => 'string',
@@ -489,7 +499,7 @@ function blc_register_settings_sections() {
 
     add_settings_section(
         'blc_soft_404_section',
-        __('Détection des soft 404', 'liens-morts-detector-jlg'),
+        __('Détection de soft 404', 'liens-morts-detector-jlg'),
         '__return_false',
         $page
     );
@@ -507,6 +517,21 @@ function blc_register_settings_sections() {
             'unit'        => __('caractères', 'liens-morts-detector-jlg'),
             'description' => __('Considère une page suspecte si le texte est plus court que ce seuil. (Défaut : 512)', 'liens-morts-detector-jlg'),
             'label_for'   => 'blc_soft_404_min_length',
+        )
+    );
+
+    add_settings_field(
+        'blc_soft_404_title_weight',
+        __('⚖️ Pondération du titre', 'liens-morts-detector-jlg'),
+        'blc_render_number_field',
+        $page,
+        'blc_soft_404_section',
+        array(
+            'option_name' => 'blc_soft_404_title_weight',
+            'min'         => 0,
+            'step'        => 0.1,
+            'description' => __('Ajuste l’influence du titre dans les heuristiques. (Défaut : 1)', 'liens-morts-detector-jlg'),
+            'label_for'   => 'blc_soft_404_title_weight',
         )
     );
 
@@ -2191,6 +2216,27 @@ function blc_sanitize_soft_404_min_length_option($value) {
     }
 
     return $sanitized;
+}
+
+/**
+ * Sanitize la pondération appliquée aux titres pour détecter les soft 404.
+ *
+ * @param mixed $value Valeur brute.
+ *
+ * @return float
+ */
+function blc_sanitize_soft_404_title_weight_option($value) {
+    $weight = is_numeric($value) ? (float) $value : 0.0;
+
+    if ($weight < 0) {
+        $weight = 0.0;
+    }
+
+    if (!is_finite($weight)) {
+        $weight = 0.0;
+    }
+
+    return $weight;
 }
 
 /**

--- a/liens-morts-detector-jlg/includes/blc-utils.php
+++ b/liens-morts-detector-jlg/includes/blc-utils.php
@@ -1906,7 +1906,13 @@ function blc_get_soft_404_default_ignore_patterns() {
 /**
  * Récupère la configuration normalisée des heuristiques soft 404.
  *
- * @return array{min_length:int,title_indicators:string[],body_indicators:string[],ignore_patterns:string[]}
+ * @return array{
+ *     min_length:int,
+ *     title_weight:float,
+ *     title_indicators:string[],
+ *     body_indicators:string[],
+ *     ignore_patterns:string[]
+ * }
  */
 function blc_get_soft_404_heuristics() {
     $default_titles = blc_get_soft_404_default_title_indicators();
@@ -1915,6 +1921,12 @@ function blc_get_soft_404_heuristics() {
 
     $min_length_option = get_option('blc_soft_404_min_length', 512);
     $min_length = max(0, (int) $min_length_option);
+
+    $title_weight_option = get_option('blc_soft_404_title_weight', 1.0);
+    $title_weight = (float) $title_weight_option;
+    if (!is_finite($title_weight) || $title_weight < 0) {
+        $title_weight = 0.0;
+    }
 
     $raw_titles = get_option('blc_soft_404_title_indicators', implode("\n", $default_titles));
     $raw_bodies = get_option('blc_soft_404_body_indicators', implode("\n", $default_bodies));
@@ -1925,6 +1937,10 @@ function blc_get_soft_404_heuristics() {
     $ignore_patterns = blc_parse_multiline_text_option($raw_ignore);
 
     $min_length = (int) apply_filters('blc_soft_404_min_length', $min_length);
+    $title_weight = (float) apply_filters('blc_soft_404_title_weight', $title_weight, $min_length);
+    if (!is_finite($title_weight) || $title_weight < 0) {
+        $title_weight = 0.0;
+    }
 
     $title_indicators = apply_filters('blc_soft_404_title_indicators', $title_indicators, $min_length);
     if (!is_array($title_indicators)) {
@@ -1952,6 +1968,7 @@ function blc_get_soft_404_heuristics() {
 
     return [
         'min_length'       => $min_length,
+        'title_weight'     => $title_weight,
         'title_indicators' => $title_indicators,
         'body_indicators'  => $body_indicators,
         'ignore_patterns'  => $ignore_patterns,

--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -356,6 +356,7 @@ function blc_enqueue_admin_assets($hook) {
         'blcAdminSoft404Config',
         array(
             'minLength'       => isset($soft_404_config['min_length']) ? (int) $soft_404_config['min_length'] : 0,
+            'titleWeight'     => isset($soft_404_config['title_weight']) ? (float) $soft_404_config['title_weight'] : 0.0,
             'titleIndicators' => isset($soft_404_config['title_indicators']) && is_array($soft_404_config['title_indicators'])
                 ? array_values($soft_404_config['title_indicators'])
                 : array(),
@@ -369,6 +370,7 @@ function blc_enqueue_admin_assets($hook) {
                 'length' => __('Contenu trop court', 'liens-morts-detector-jlg'),
                 'title'  => __('Titre suspect', 'liens-morts-detector-jlg'),
                 'body'   => __('Message d’erreur détecté', 'liens-morts-detector-jlg'),
+                'titleWeight' => __('Pondération du titre', 'liens-morts-detector-jlg'),
             ),
         )
     );


### PR DESCRIPTION
## Summary
- register and render the soft 404 title weighting option alongside existing heuristics fields with sanitization and translations
- include the new weighting in heuristics utilities and expose localized labels/data to the admin script
- update admin JavaScript and tests to normalize and assert the extended soft 404 configuration

## Testing
- npm test -- --runTestsByPath liens-morts-detector-jlg/assets/js/__tests__/blc-admin-scripts.test.js

------
https://chatgpt.com/codex/tasks/task_e_68e2a2886dd0832eb8d793229e7ce09b