### PR TITLE
Refactor image scan queue and add targeted tests

### DIFF
--- a/liens-morts-detector-jlg/includes/Scanner/ImageUrlNormalizer.php
+++ b/liens-morts-detector-jlg/includes/Scanner/ImageUrlNormalizer.php
@@ -1,0 +1,212 @@
+<?php
+
+if (!class_exists('BlcImageUrlNormalizer')) {
+    class BlcImageUrlNormalizer {
+        /**
+         * @var string
+         */
+        private $homeUrlWithTrailingSlash;
+
+        /**
+         * @var string
+         */
+        private $siteScheme;
+
+        /**
+         * @var string
+         */
+        private $normalizedSiteHost;
+
+        /**
+         * @var string
+         */
+        private $uploadBaseurlHost;
+
+        /**
+         * @var string
+         */
+        private $uploadBaseurl;
+
+        /**
+         * @var string
+         */
+        private $uploadBasedir;
+
+        /**
+         * @var string
+         */
+        private $normalizedBasedir;
+
+        /**
+         * @var bool
+         */
+        private $remoteImageScanEnabled;
+
+        /**
+         * @var bool
+         */
+        private $debugMode;
+
+        public function __construct(
+            $home_url_with_trailing_slash,
+            $site_scheme,
+            $normalized_site_host,
+            $upload_baseurl_host,
+            $upload_baseurl,
+            $upload_basedir,
+            $normalized_basedir,
+            $remote_image_scan_enabled,
+            $debug_mode
+        ) {
+            $this->homeUrlWithTrailingSlash = (string) $home_url_with_trailing_slash;
+            $this->siteScheme = (string) $site_scheme;
+            $this->normalizedSiteHost = (string) $normalized_site_host;
+            $this->uploadBaseurlHost = (string) $upload_baseurl_host;
+            $this->uploadBaseurl = (string) $upload_baseurl;
+            $this->uploadBasedir = (string) $upload_basedir;
+            $this->normalizedBasedir = (string) $normalized_basedir;
+            $this->remoteImageScanEnabled = (bool) $remote_image_scan_enabled;
+            $this->debugMode = (bool) $debug_mode;
+        }
+
+        /**
+         * Normalize a candidate image URL and return path metadata.
+         *
+         * @param string $candidate_url Raw URL extracted from the DOM.
+         * @param string $permalink     Permalink of the scanned post.
+         *
+         * @return array<string, mixed>|null
+         */
+        public function normalize($candidate_url, $permalink) {
+            $candidate_url = trim((string) $candidate_url);
+            if ($candidate_url === '') {
+                return null;
+            }
+
+            $normalized_image_url = blc_normalize_link_url(
+                $candidate_url,
+                $this->homeUrlWithTrailingSlash,
+                $this->siteScheme,
+                $permalink
+            );
+
+            if (!is_string($normalized_image_url) || $normalized_image_url === '') {
+                return null;
+            }
+
+            $image_host_raw = parse_url($normalized_image_url, PHP_URL_HOST);
+            $image_host = is_string($image_host_raw) ? blc_normalize_remote_host($image_host_raw) : '';
+            if ($image_host === '') {
+                return null;
+            }
+
+            $hosts_match_site = ($image_host !== '' && $this->normalizedSiteHost !== '' && $image_host === $this->normalizedSiteHost);
+            $hosts_match_upload = ($image_host !== '' && $this->uploadBaseurlHost !== '' && $image_host === $this->uploadBaseurlHost);
+            $is_remote_upload_candidate = false;
+
+            if (!$hosts_match_site && !$hosts_match_upload) {
+                if (!$this->remoteImageScanEnabled) {
+                    if ($this->debugMode) {
+                        error_log("  -> Image distante ignorée (analyse désactivée) : " . $normalized_image_url);
+                    }
+                    return null;
+                }
+
+                $is_safe_remote_host = blc_is_safe_remote_host($image_host);
+                if (!$is_safe_remote_host) {
+                    if ($this->debugMode) {
+                        error_log("  -> Image ignorée (IP non autorisée) : " . $normalized_image_url);
+                    }
+                    return null;
+                }
+
+                $is_remote_upload_candidate = true;
+            } elseif (!$hosts_match_site && $hosts_match_upload) {
+                $is_safe_remote_host = blc_is_safe_remote_host($image_host);
+                if (!$is_safe_remote_host) {
+                    if ($this->debugMode) {
+                        error_log("  -> Image ignorée (IP non autorisée) : " . $normalized_image_url);
+                    }
+                    return null;
+                }
+            }
+
+            if ($this->uploadBaseurl === '' || $this->uploadBasedir === '' || $this->normalizedBasedir === '') {
+                return null;
+            }
+
+            $image_scheme = parse_url($normalized_image_url, PHP_URL_SCHEME);
+            $normalized_upload_baseurl = $this->uploadBaseurl;
+            if ($image_scheme && $this->uploadBaseurl !== '') {
+                $normalized_upload_baseurl = set_url_scheme($this->uploadBaseurl, $image_scheme);
+            }
+
+            $normalized_upload_baseurl_length = strlen($normalized_upload_baseurl);
+            if ($normalized_upload_baseurl_length === 0) {
+                return null;
+            }
+
+            if (
+                !$is_remote_upload_candidate &&
+                strncasecmp($normalized_image_url, $normalized_upload_baseurl, $normalized_upload_baseurl_length) !== 0
+            ) {
+                return null;
+            }
+
+            $image_path_from_url = function_exists('wp_parse_url')
+                ? wp_parse_url($normalized_image_url, PHP_URL_PATH)
+                : parse_url($normalized_image_url, PHP_URL_PATH);
+            if (!is_string($image_path_from_url) || $image_path_from_url === '') {
+                return null;
+            }
+
+            $image_path = wp_normalize_path($image_path_from_url);
+
+            $parsed_upload_baseurl = function_exists('wp_parse_url') ? wp_parse_url($normalized_upload_baseurl) : parse_url($normalized_upload_baseurl);
+            $upload_base_path = '';
+            if (is_array($parsed_upload_baseurl) && !empty($parsed_upload_baseurl['path'])) {
+                $upload_base_path = wp_normalize_path($parsed_upload_baseurl['path']);
+            }
+
+            $upload_base_path_trimmed = ltrim(trailingslashit($upload_base_path), '/');
+            $upload_base_path_trimmed_length = strlen($upload_base_path_trimmed);
+            $image_path_trimmed = ltrim($image_path, '/');
+
+            if (
+                $upload_base_path_trimmed_length === 0 ||
+                strncasecmp($image_path_trimmed, $upload_base_path_trimmed, $upload_base_path_trimmed_length) !== 0
+            ) {
+                return null;
+            }
+
+            $relative_path = ltrim(substr($image_path_trimmed, $upload_base_path_trimmed_length), '/');
+            if ($relative_path === '') {
+                return null;
+            }
+
+            $decoded_relative_path = rawurldecode($relative_path);
+            $decoded_relative_path = ltrim($decoded_relative_path, '/\\');
+            if ($decoded_relative_path === '') {
+                return null;
+            }
+
+            if (preg_match('#(^|[\\/])\.\.([\\/]|$)#', $decoded_relative_path)) {
+                return null;
+            }
+
+            $file_path = wp_normalize_path(trailingslashit($this->uploadBasedir) . $decoded_relative_path);
+            if (strpos($file_path, $this->normalizedBasedir) !== 0) {
+                return null;
+            }
+
+            return [
+                'original_url'              => $candidate_url,
+                'normalized_url'            => $normalized_image_url,
+                'file_path'                 => $file_path,
+                'decoded_relative_path'     => $decoded_relative_path,
+                'is_remote_upload_candidate' => $is_remote_upload_candidate,
+            ];
+        }
+    }
+}
+

--- a/tests/Scanner/ImageScanQueueTest.php
+++ b/tests/Scanner/ImageScanQueueTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace {
+    if (!class_exists('WP_Query')) {
+        class WP_Query
+        {
+            public $posts = [];
+
+            public $max_num_pages = 0;
+
+            public $found_posts = 0;
+
+            public $args = [];
+
+            public function __construct($args = [])
+            {
+                $this->args = $args;
+                $scenario = [];
+                if (!empty($GLOBALS['wp_query_queue'])) {
+                    $scenario = array_shift($GLOBALS['wp_query_queue']);
+                }
+
+                $this->posts = $scenario['posts'] ?? [];
+                $this->max_num_pages = $scenario['max_num_pages'] ?? 0;
+                if (isset($scenario['found_posts'])) {
+                    $this->found_posts = (int) $scenario['found_posts'];
+                } else {
+                    $this->found_posts = is_array($this->posts) ? count($this->posts) : 0;
+                }
+            }
+        }
+    }
+}
+
+namespace Tests\Scanner {
+
+use Brain\Monkey\Functions;
+
+class ImageScanQueueTest extends ScannerTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Functions\when('wp_basename')->alias('basename');
+        Functions\when('get_permalink')->alias(fn($post) => 'https://example.com/sample-post');
+        Functions\when('blc_adjust_dataset_storage_footprint')->alias(function () {
+        });
+        Functions\when('blc_refresh_image_scan_lock')->alias(function () {
+        });
+        Functions\when('blc_is_safe_remote_host')->alias(fn() => true);
+        Functions\when('get_post_types')->alias(fn($args = [], $output = 'names') => ['post']);
+        Functions\when('get_post_stati')->alias(fn($args = [], $output = 'names') => ['publish']);
+        Functions\when('wp_reset_postdata')->alias(function () {
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['wp_query_queue'], $GLOBALS['wp_query_last_args']);
+        parent::tearDown();
+    }
+
+    public function test_run_reschedules_when_lock_unavailable(): void
+    {
+        Functions\expect('blc_acquire_image_scan_lock')->once()->andReturn('');
+
+        $queue = new \ImageScanQueue();
+        $queue->run(0, true);
+
+        $this->assertCount(1, $this->scheduledEvents);
+        $event = $this->scheduledEvents[0];
+        $this->assertSame('blc_check_image_batch', $event['hook']);
+        $this->assertSame([0, true], $event['args']);
+        $this->assertSame([], $this->wpdb->insertedRows);
+    }
+
+    public function test_run_skips_remote_images_when_disabled(): void
+    {
+        $this->options['blc_remote_image_scan_enabled'] = false;
+        $GLOBALS['wp_query_queue'] = [[
+            'posts' => [
+                (object) [
+                    'ID'           => 101,
+                    'post_title'   => 'Remote image post',
+                    'post_content' => '<p><img src="https://cdn.example.net/wp-content/uploads/2024/01/photo.jpg" /></p>',
+                ],
+            ],
+            'max_num_pages' => 1,
+        ]];
+
+        Functions\expect('blc_acquire_image_scan_lock')->once()->andReturn('image-lock');
+        Functions\expect('blc_generate_scan_run_token')->once()->andReturn('run-token');
+        Functions\expect('blc_stage_dataset_refresh')->once()->andReturn(true);
+        Functions\expect('blc_commit_dataset_refresh')->once()->andReturn(true);
+        Functions\expect('blc_maybe_send_scan_summary')->once()->with('image');
+
+        $release_calls = [];
+        Functions\when('blc_release_image_scan_lock')->alias(function ($token) use (&$release_calls) {
+            $release_calls[] = $token;
+        });
+
+        $queue = new \ImageScanQueue();
+        $queue->run(0, true);
+
+        $this->assertSame([], $this->wpdb->insertedRows, 'No broken images should be recorded when remote scanning is disabled.');
+        $this->assertSame(['image-lock'], $release_calls, 'Lock should be released after successful run.');
+    }
+
+    public function test_run_cleans_up_on_exception(): void
+    {
+        $this->options['blc_remote_image_scan_enabled'] = false;
+        $GLOBALS['wp_query_queue'] = [[
+            'posts' => [
+                (object) [
+                    'ID'           => 202,
+                    'post_title'   => 'Broken local image',
+                    'post_content' => '<p><img src="https://example.com/wp-content/uploads/2024/02/missing.jpg" /></p>',
+                ],
+            ],
+            'max_num_pages' => 1,
+        ]];
+
+        $adjustments = [];
+        Functions\when('blc_adjust_dataset_storage_footprint')->alias(function ($type, $delta) use (&$adjustments) {
+            $adjustments[] = [$type, $delta];
+        });
+
+        Functions\expect('blc_acquire_image_scan_lock')->once()->andReturn('error-lock');
+        $release_calls = [];
+        Functions\when('blc_release_image_scan_lock')->alias(function ($token) use (&$release_calls) {
+            $release_calls[] = $token;
+        });
+        Functions\expect('blc_generate_scan_run_token')->once()->andReturn('run-token');
+        Functions\expect('blc_stage_dataset_refresh')->once()->andReturn(true);
+        Functions\expect('blc_commit_dataset_refresh')->once()->andThrow(new \RuntimeException('Commit failure'));
+        Functions\expect('blc_maybe_send_scan_summary')->never();
+
+        $restore_calls = [];
+        Functions\when('blc_restore_dataset_refresh')->alias(function (...$args) use (&$restore_calls) {
+            $restore_calls[] = $args;
+        });
+
+        $queue = new \ImageScanQueue();
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Commit failure');
+        try {
+            $queue->run(0, true);
+        } finally {
+            $this->assertNotEmpty($this->wpdb->insertedRows, 'Broken image insertion should have been attempted.');
+            $this->assertNotEmpty($adjustments, 'Storage footprint adjustments should be recorded.');
+            $this->assertSame('image', $adjustments[0][0]);
+            $this->assertGreaterThan(0, $adjustments[0][1]);
+            $this->assertNotEmpty($restore_calls, 'Dataset refresh should be restored when an exception occurs.');
+            $this->assertSame('error-lock', $release_calls[0] ?? null, 'Lock should be released after exception.');
+        }
+    }
+}
+}

--- a/tests/Scanner/ScannerTestCase.php
+++ b/tests/Scanner/ScannerTestCase.php
@@ -370,13 +370,11 @@ abstract class ScannerTestCase extends TestCase
             });
         }
 
-        if (!function_exists('sanitize_key')) {
-            Functions\when('sanitize_key')->alias(function ($key) {
-                $key = strtolower(is_scalar($key) ? (string) $key : '');
+        Functions\when('sanitize_key')->alias(function ($key) {
+            $key = strtolower(is_scalar($key) ? (string) $key : '');
 
-                return preg_replace('/[^a-z0-9_\-]/', '', $key);
-            });
-        }
+            return preg_replace('/[^a-z0-9_\-]/', '', $key);
+        });
 
         Functions\when('maybe_unserialize')->alias(function ($value) {
             if (!is_string($value)) {


### PR DESCRIPTION
## Summary
- split the image scan queue into dedicated helpers and track pending inserts for cleanup
- introduce `BlcImageUrlNormalizer` to consolidate URL and path normalization for image candidates
- add PHPUnit coverage for lock contention, remote image filtering, and exception cleanup flows

## Testing
- `vendor/bin/phpunit tests/Scanner/ImageScanQueueTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68e2b6d969e4832e9f79d76ef9961f4f