### PR TITLE
Handle custom user agent headers in RemoteRequestClient

### DIFF
--- a/liens-morts-detector-jlg/includes/Scanner/RemoteRequestClient.php
+++ b/liens-morts-detector-jlg/includes/Scanner/RemoteRequestClient.php
@@ -125,15 +125,42 @@ class RemoteRequestClient
         $prepared = array_merge($this->defaultArgs, $args);
 
         $userAgent = $this->pickUserAgent($attempt);
-        if (!isset($prepared['headers']) || !is_array($prepared['headers'])) {
-            $prepared['headers'] = [];
+
+        $headers = [];
+        if (isset($prepared['headers']) && is_array($prepared['headers'])) {
+            $headers = $prepared['headers'];
         }
 
-        if (!isset($prepared['headers']['User-Agent'])) {
-            $prepared['headers']['User-Agent'] = $userAgent;
+        $existingHeaderKey = null;
+        foreach ($headers as $name => $value) {
+            if (!is_string($name)) {
+                continue;
+            }
+
+            if (strcasecmp($name, 'User-Agent') !== 0) {
+                continue;
+            }
+
+            $existingHeaderKey = $name;
+
+            if (is_scalar($value)) {
+                $candidate = trim((string) $value);
+                if ($candidate !== '') {
+                    $userAgent = $candidate;
+                }
+            }
+
+            break;
         }
 
-        $prepared['user-agent'] = $prepared['headers']['User-Agent'];
+        if ($existingHeaderKey === null) {
+            $existingHeaderKey = 'User-Agent';
+        }
+
+        $headers[$existingHeaderKey] = $userAgent;
+
+        $prepared['headers'] = $headers;
+        $prepared['user-agent'] = $userAgent;
 
         return $prepared;
     }


### PR DESCRIPTION
## Summary
- ensure RemoteRequestClient preserves caller-provided user agent headers regardless of casing and falls back to its pool when blank
- add regression tests covering custom and empty user agent headers

## Testing
- npm test
- ./vendor/bin/phpunit tests/Scanner/RemoteRequestClientTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e39c710fe8832e9a5e152b0132a8e6