### PR TITLE
Add observability history dashboard

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -105,6 +105,19 @@
     cursor: pointer;
 }
 
+.blc-stat--static {
+    cursor: default;
+}
+
+.blc-stat--static:hover,
+.blc-stat--static:focus,
+.blc-stat--static:focus-visible {
+    background-color: #f6f7f7;
+    border-color: #dcdcde;
+    color: #1d2327;
+    box-shadow: none;
+}
+
 .blc-stat.is-active {
     background-color: #f0f6fc;
     border-color: #2271b1;
@@ -200,6 +213,129 @@
 @media (prefers-reduced-motion: reduce) {
     .blc-stat {
         transition: none;
+    }
+}
+
+.blc-history-page h2 {
+    margin-top: 32px;
+}
+
+.blc-history-page .blc-history-last-run {
+    background-color: #ffffff;
+    border: 1px solid #c3c4c7;
+    border-left: 4px solid #72aee6;
+    padding: 20px;
+    margin-bottom: 24px;
+}
+
+.blc-history-last-run__header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.blc-history-last-run__job,
+.blc-history-last-run__mode {
+    font-weight: 500;
+}
+
+.blc-history-last-run__details,
+.blc-history-list,
+.blc-history-notes {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+}
+
+.blc-history-last-run__details li,
+.blc-history-list li {
+    margin-bottom: 6px;
+}
+
+.blc-history-notes li {
+    margin-bottom: 4px;
+    font-style: italic;
+    color: #50575e;
+}
+
+.blc-history-state {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 4px 12px;
+    border-radius: 999px;
+    background-color: #f1f1f1;
+    color: #1d2327;
+    font-weight: 600;
+    font-size: 13px;
+}
+
+.blc-history-state.is-success {
+    background-color: #e6f4ea;
+    color: #0a5c2a;
+}
+
+.blc-history-state.is-error {
+    background-color: #fde8e8;
+    color: #9d0208;
+}
+
+.blc-history-state.is-running {
+    background-color: #e8f0fe;
+    color: #1d4ed8;
+}
+
+.blc-history-state.is-queued {
+    background-color: #fff4e5;
+    color: #b45309;
+}
+
+.blc-history-state.is-cancelled,
+.blc-history-state.is-idle {
+    background-color: #f6f7f7;
+    color: #50575e;
+}
+
+.blc-history-message {
+    margin: 0 0 6px;
+}
+
+.blc-history-error {
+    margin: 0 0 6px;
+    color: #9d0208;
+    font-weight: 600;
+}
+
+.blc-history-empty-message {
+    text-align: center;
+    color: #50575e;
+    font-style: italic;
+}
+
+.blc-history-meta {
+    font-size: 13px;
+    color: #50575e;
+    margin-top: 4px;
+}
+
+.blc-history-table {
+    margin-top: 12px;
+}
+
+.blc-history-table-section {
+    margin-bottom: 32px;
+}
+
+@media (max-width: 782px) {
+    .blc-history-last-run__header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .blc-history-state {
+        margin-bottom: 8px;
     }
 }
 

--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -128,7 +128,12 @@ add_action('admin_enqueue_scripts', 'blc_enqueue_admin_assets');
  */
 function blc_enqueue_admin_assets($hook) {
     // On s'assure de ne charger les scripts que sur nos pages pour ne pas alourdir le reste de l'admin.
-    if (strpos($hook, 'blc-dashboard') === false && strpos($hook, 'blc-images-dashboard') === false && strpos($hook, 'blc-settings') === false) {
+    if (
+        strpos($hook, 'blc-dashboard') === false
+        && strpos($hook, 'blc-images-dashboard') === false
+        && strpos($hook, 'blc-history') === false
+        && strpos($hook, 'blc-settings') === false
+    ) {
         return;
     }
     

--- a/tests/BlcScanHistoryPageTest.php
+++ b/tests/BlcScanHistoryPageTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace {
+    require_once __DIR__ . '/translation-stubs.php';
+    require_once __DIR__ . '/wp-option-stubs.php';
+
+    if (!function_exists('sanitize_key')) {
+        function sanitize_key($key)
+        {
+            $key = strtolower((string) $key);
+
+            return preg_replace('/[^a-z0-9_\-]/', '', $key);
+        }
+    }
+}
+
+namespace Tests {
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+use Tests\Stubs\OptionsStore;
+
+class BlcScanHistoryPageTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        require_once __DIR__ . '/../vendor/autoload.php';
+        Monkey\setUp();
+
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', __DIR__ . '/../');
+        }
+
+        OptionsStore::reset();
+
+        require_once __DIR__ . '/../liens-morts-detector-jlg/includes/blc-scanner.php';
+        require_once __DIR__ . '/../liens-morts-detector-jlg/includes/blc-admin-pages.php';
+
+        Functions\when('admin_url')->alias(static function ($path = '') {
+            return 'admin.php?page=' . ltrim((string) $path, '?');
+        });
+
+        Functions\when('number_format_i18n')->alias(static function ($number, $decimals = 0) {
+            return number_format((float) $number, (int) $decimals, ',', ' ');
+        });
+
+        Functions\when('wp_date')->alias(static function ($format, $timestamp = null) {
+            $timestamp = $timestamp ?? time();
+
+            return gmdate($format, $timestamp);
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_calculate_link_scan_history_insights_returns_expected_metrics(): void
+    {
+        $history = [
+            [
+                'job_id'          => 'blc_123',
+                'state'           => 'completed',
+                'scheduled_at'    => 1700000000,
+                'started_at'      => 1700000300,
+                'ended_at'        => 1700000600,
+                'processed_items' => 120,
+                'total_items'     => 120,
+                'metrics'         => [
+                    'duration_ms'      => 300000,
+                    'processed_items'  => 120,
+                    'total_items'      => 120,
+                    'processed_batches'=> 4,
+                    'total_batches'    => 4,
+                ],
+            ],
+            [
+                'job_id'       => 'blc_456',
+                'state'        => 'failed',
+                'scheduled_at' => 1700000800,
+                'attempt'      => 2,
+            ],
+        ];
+
+        $insights = blc_calculate_link_scan_history_insights($history);
+
+        $this->assertSame(2, $insights['total_runs']);
+        $this->assertSame(1, $insights['completed_runs']);
+        $this->assertSame(1, $insights['failed_runs']);
+        $this->assertEqualsWithDelta(300000.0, $insights['average_duration_ms'], 0.1);
+        $this->assertEqualsWithDelta(24.0, $insights['average_throughput'], 0.1);
+        $this->assertSame('blc_123', $insights['last_job_summary']['job_id']);
+        $this->assertSame('completed', $insights['last_job_summary']['state']);
+    }
+
+    public function test_history_page_renders_tables_and_summary(): void
+    {
+        OptionsStore::$options['blc_link_scan_history'] = [
+            [
+                'job_id'             => 'blc_123',
+                'state'              => 'completed',
+                'scheduled_at'       => 1700000000,
+                'started_at'         => 1700000300,
+                'ended_at'           => 1700000600,
+                'processed_items'    => 120,
+                'total_items'        => 120,
+                'processed_batches'  => 4,
+                'total_batches'      => 4,
+                'is_full_scan'       => true,
+                'attempt'            => 1,
+                'message'            => 'Scan terminé avec succès.',
+                'metrics'            => [
+                    'duration_ms'      => 300000,
+                    'processed_items'  => 120,
+                    'total_items'      => 120,
+                    'processed_batches'=> 4,
+                    'total_batches'    => 4,
+                    'timestamp'        => 1700000600,
+                    'success'          => true,
+                    'state'            => 'completed',
+                    'is_full_scan'     => true,
+                    'attempt'          => 1,
+                ],
+            ],
+        ];
+
+        OptionsStore::$options['blc_link_scan_metrics_history'] = [
+            [
+                'job_id'            => 'blc_123',
+                'batch'             => 0,
+                'duration_ms'       => 120000,
+                'timestamp'         => 1700000400,
+                'processed_items'   => 60,
+                'total_items'       => 120,
+                'processed_batches' => 2,
+                'total_batches'     => 4,
+                'success'           => true,
+                'state'             => 'running',
+                'is_full_scan'      => true,
+                'attempt'           => 1,
+            ],
+        ];
+
+        ob_start();
+        blc_scan_history_page();
+        $output = (string) ob_get_clean();
+
+        $this->assertStringContainsString('Historique des Analyses', $output);
+        $this->assertStringContainsString('Analyses totales', $output);
+        $this->assertStringContainsString('blc_123', $output);
+        $this->assertStringContainsString('Scan terminé avec succès.', $output);
+        $this->assertStringContainsString('Succès', $output);
+        $this->assertStringContainsString('Analyse en cours', $output);
+    }
+}
+
+}


### PR DESCRIPTION
## Summary
- add a dedicated "Historique" admin page to surface scan history and per-batch telemetry
- expose helper utilities to compute scan insights and retrieve metrics history for the dashboard
- style the new dashboard components and ensure assets load on the history screen

## Testing
- vendor/bin/phpunit tests/BlcScanHistoryPageTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e432f8f3b8832e8a1929ded084917a