### PR TITLE
Respect image scan mode in status tracking

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -714,7 +714,9 @@ if (!function_exists('blc_get_image_scan_status')) {
             $status[$numeric_key] = isset($status[$numeric_key]) ? max(0, (int) $status[$numeric_key]) : 0;
         }
 
-        $status['is_full_scan'] = true;
+        $status['is_full_scan'] = array_key_exists('is_full_scan', $status)
+            ? (bool) $status['is_full_scan']
+            : true;
         $status['message'] = isset($status['message']) && is_string($status['message']) ? $status['message'] : '';
         $status['last_error'] = isset($status['last_error']) && is_string($status['last_error']) ? $status['last_error'] : '';
 
@@ -790,7 +792,11 @@ if (!function_exists('blc_update_image_scan_status')) {
         }
 
         $status['updated_at'] = $now;
-        $status['is_full_scan'] = true;
+        if (array_key_exists('is_full_scan', $status)) {
+            $status['is_full_scan'] = (bool) $status['is_full_scan'];
+        } else {
+            $status['is_full_scan'] = true;
+        }
 
         update_option('blc_image_scan_status', $status, false);
 

--- a/tests/LinkScanStatusTest.php
+++ b/tests/LinkScanStatusTest.php
@@ -225,6 +225,31 @@ class LinkScanStatusTest extends TestCase
         $this->assertSame(75, $status['updated_at']);
     }
 
+    public function test_get_image_scan_status_preserves_is_full_scan_flag(): void
+    {
+        $this->options['blc_image_scan_status'] = [
+            'state' => 'running',
+            'is_full_scan' => false,
+        ];
+
+        $status = \blc_get_image_scan_status();
+
+        $this->assertFalse($status['is_full_scan']);
+    }
+
+    public function test_update_image_scan_status_accepts_partial_runs(): void
+    {
+        Functions\when('time')->alias(static fn() => 200);
+
+        $status = \blc_update_image_scan_status([
+            'state' => 'running',
+            'is_full_scan' => false,
+        ]);
+
+        $this->assertFalse($status['is_full_scan']);
+        $this->assertFalse($this->options['blc_image_scan_status']['is_full_scan']);
+    }
+
     public function test_get_link_scan_status_payload_includes_metrics(): void
     {
         $now = 200;


### PR DESCRIPTION
## Summary
- preserve the stored `is_full_scan` flag when reading and updating the image scan status
- ensure the status cache normalises the flag without forcing a full scan
- add unit tests covering partial image scan runs

## Testing
- vendor/bin/phpunit tests/LinkScanStatusTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e4ddf068b8832e85ec50103e3a448b