### PR TITLE
Add automated report export scheduler and tests

### DIFF
--- a/docs/ameliorations-et-tests.md
+++ b/docs/ameliorations-et-tests.md
@@ -10,11 +10,13 @@
 
 - **`Tests\BlcManualScanSchedulingTest`** : une nouvelle suite PHPUnit/Brain Monkey qui vérifie le comportement de `blc_schedule_manual_link_scan` lorsque la planification échoue, lorsqu'elle réussit et lorsque le déclenchement manuel via `spawn_cron()` échoue. Ces tests facilitent l'identification rapide des régressions liées à la fiabilité de la planification. 【F:tests/BlcManualScanSchedulingTest.php†L1-L224】
 - **`Tests\LinkScanStatusTest`** : enrichi pour couvrir le cache mémoire par requête, la purge via `blc_reset_link_scan_status()` et les métriques exposées dans le payload (pourcentage d'avancement, débit par minute, temps restant estimé). Ces assertions détectent les régressions de performance et garantissent la cohérence des données présentées à l'interface. 【F:tests/LinkScanStatusTest.php†L12-L187】
+- **`Tests\BlcReportExportsTest`** : vérifie la synchronisation de la nouvelle planification d'exports, la génération de CSV lorsqu'un scan est terminé et l'enregistrement des tentatives ignorées pour éviter les doublons. Ces tests sécurisent l'itération sur les rapports automatisés. 【F:tests/BlcReportExportsTest.php†L1-L357】
 
 ## Améliorations réalisées
 
 - **`blc_get_link_scan_status_payload`** calcule désormais des métriques opérationnelles (pourcentage d'avancement, éléments restants, durée, débit par minute, estimation d'achèvement) et les expose à l'interface et à l'API REST pour un suivi plus transparent. 【F:liens-morts-detector-jlg/includes/blc-scanner.php†L10-L102】【F:liens-morts-detector-jlg/includes/blc-scanner.php†L366-L408】
 - **`blc_get_link_scan_status`** et **`blc_get_image_scan_status`** utilisent un cache mémoire par requête pour limiter les lectures répétitives de la base de données lors d'appels successifs, améliorant la charge serveur pendant les écrans de suivi. 【F:liens-morts-detector-jlg/includes/blc-scanner.php†L10-L102】【F:liens-morts-detector-jlg/includes/blc-scanner.php†L446-L544】
+- **Exports automatisés** : une nouvelle planification `blc_generate_report_exports` sérialise les résultats du dernier scan en CSV dans `wp-content/uploads/blc-report-exports`, mémorise les tentatives et évite les re-générations inutiles. 【F:liens-morts-detector-jlg/includes/blc-reports.php†L1-L330】【F:liens-morts-detector-jlg/includes/blc-cron.php†L626-L742】【F:liens-morts-detector-jlg/includes/blc-activation.php†L81-L118】
 
 ## Tests manuels recommandés
 

--- a/docs/roadmap-ameliorations.md
+++ b/docs/roadmap-ameliorations.md
@@ -13,6 +13,8 @@ Cette feuille de route décline les pistes d'amélioration listées dans le `REA
 2. Ajouter un connecteur Google Sheets via l'API REST avec rotation automatique des tokens OAuth.
 3. Implémenter un upload vers des services S3 compatibles (AWS, Scaleway) avec configuration multi-endpoints.
 
+> ✅ Le scheduler `blc_generate_report_exports` est désormais disponible : il prépare le répertoire `blc-report-exports`, génère un CSV après chaque scan terminé et conserve l'historique des tentatives pour éviter les doublons. 【F:liens-morts-detector-jlg/includes/blc-reports.php†L1-L330】【F:liens-morts-detector-jlg/includes/blc-cron.php†L626-L742】
+
 **Indicateurs de réussite**
 - Temps moyen de génération < 30 secondes pour 10 000 liens.
 - Taux d'erreurs d'export < 1 % par semaine.

--- a/liens-morts-detector-jlg/includes/blc-activation.php
+++ b/liens-morts-detector-jlg/includes/blc-activation.php
@@ -375,6 +375,18 @@ function blc_activate_site() {
 
     blc_maybe_upgrade_database();
 
+    if (get_option('blc_report_export_enabled', null) === null) {
+        add_option('blc_report_export_enabled', false, '', false);
+    }
+
+    if (get_option('blc_report_export_frequency', null) === null) {
+        add_option('blc_report_export_frequency', 'daily', '', false);
+    }
+
+    if (function_exists('blc_sync_report_export_schedule')) {
+        blc_sync_report_export_schedule();
+    }
+
     // On récupère la fréquence de scan enregistrée, ou 'daily' par défaut
     $frequency_option = get_option('blc_frequency', 'daily');
     $frequency_option = is_string($frequency_option) ? trim($frequency_option) : '';
@@ -522,6 +534,7 @@ function blc_deactivate_site() {
     wp_clear_scheduled_hook('blc_check_batch');
     wp_clear_scheduled_hook('blc_manual_check_batch');
     wp_clear_scheduled_hook('blc_check_image_batch', array(0, true));
+    wp_clear_scheduled_hook('blc_generate_report_exports');
 }
 
 function blc_deactivation($network_wide = false) {

--- a/liens-morts-detector-jlg/includes/blc-reports.php
+++ b/liens-morts-detector-jlg/includes/blc-reports.php
@@ -1,0 +1,498 @@
+<?php
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!function_exists('blc_run_automated_report_exports')) {
+    /**
+     * Generate CSV exports for the latest completed scans.
+     *
+     * @param bool $force When true, bypass freshness checks and generate exports.
+     *
+     * @return void
+     */
+    function blc_run_automated_report_exports($force = false) {
+        if (!function_exists('blc_is_report_export_enabled') || !blc_is_report_export_enabled()) {
+            return;
+        }
+
+        $datasets = blc_get_report_export_datasets();
+        if ($datasets === []) {
+            return;
+        }
+
+        $directory = blc_prepare_report_export_directory();
+        if (function_exists('is_wp_error') && is_wp_error($directory)) {
+            blc_log_report_export_error($directory);
+
+            return;
+        }
+
+        foreach ($datasets as $dataset_type) {
+            $status = blc_get_scan_status_for_report_dataset($dataset_type);
+            if ($status === null) {
+                continue;
+            }
+
+            $previous = blc_get_previous_report_export($dataset_type);
+            if (!blc_should_generate_report_export($dataset_type, $status, $previous, $force)) {
+                blc_record_report_export_result($dataset_type, $status, null, true);
+
+                continue;
+            }
+
+            $rows = blc_collect_report_rows($dataset_type);
+            if (function_exists('is_wp_error') && is_wp_error($rows)) {
+                blc_log_report_export_error($rows);
+                blc_record_report_export_result($dataset_type, $status, null, true);
+
+                continue;
+            }
+
+            $metadata = blc_write_report_export($dataset_type, $rows, $directory, $status);
+            if (function_exists('is_wp_error') && is_wp_error($metadata)) {
+                blc_log_report_export_error($metadata);
+                blc_record_report_export_result($dataset_type, $status, null, true);
+
+                continue;
+            }
+
+            blc_record_report_export_result($dataset_type, $status, $metadata, false);
+        }
+    }
+}
+
+if (!function_exists('blc_get_report_export_datasets')) {
+    /**
+     * Retrieve the dataset identifiers that should produce CSV exports.
+     *
+     * @return string[]
+     */
+    function blc_get_report_export_datasets() {
+        $datasets = ['link', 'image'];
+
+        if (function_exists('apply_filters')) {
+            $datasets = apply_filters('blc_report_export_datasets', $datasets);
+        }
+
+        $datasets = array_filter(
+            array_map(
+                static function ($dataset) {
+                    return is_string($dataset) ? trim($dataset) : '';
+                },
+                (array) $datasets
+            ),
+            static function ($value) {
+                return $value !== '';
+            }
+        );
+
+        return array_values(array_unique($datasets));
+    }
+}
+
+if (!function_exists('blc_prepare_report_export_directory')) {
+    /**
+     * Ensure the export directory exists inside the uploads folder.
+     *
+     * @return array<string,string>|\WP_Error
+     */
+    function blc_prepare_report_export_directory() {
+        if (!function_exists('wp_upload_dir')) {
+            return new \WP_Error(
+                'blc_report_upload_dir_unavailable',
+                __('Unable to determine the uploads directory for report exports.', 'liens-morts-detector-jlg')
+            );
+        }
+
+        $uploads = wp_upload_dir();
+        if (is_array($uploads) && isset($uploads['error']) && $uploads['error']) {
+            $error_message = is_string($uploads['error'])
+                ? $uploads['error']
+                : __('Unknown uploads directory error.', 'liens-morts-detector-jlg');
+
+            return new \WP_Error('blc_report_upload_dir_error', $error_message);
+        }
+
+        $base_dir = is_array($uploads) && isset($uploads['basedir']) ? (string) $uploads['basedir'] : '';
+        $base_url = is_array($uploads) && isset($uploads['baseurl']) ? (string) $uploads['baseurl'] : '';
+
+        if ($base_dir === '') {
+            return new \WP_Error(
+                'blc_report_upload_dir_empty',
+                __('The uploads directory path is empty.', 'liens-morts-detector-jlg')
+            );
+        }
+
+        $base_dir = rtrim($base_dir, '/\\');
+        $directory = $base_dir . '/blc-report-exports';
+
+        if (!is_dir($directory)) {
+            $created = false;
+            if (function_exists('wp_mkdir_p')) {
+                $created = wp_mkdir_p($directory);
+            } else {
+                $created = mkdir($directory, 0777, true);
+            }
+
+            if (!$created) {
+                return new \WP_Error(
+                    'blc_report_export_mkdir_failed',
+                    sprintf(
+                        /* translators: %s: absolute path to the export directory. */
+                        __('Unable to create the report export directory (%s).', 'liens-morts-detector-jlg'),
+                        $directory
+                    )
+                );
+            }
+        }
+
+        $directory_url = $base_url !== '' ? rtrim($base_url, '/\\') . '/blc-report-exports' : '';
+
+        return [
+            'path' => $directory,
+            'url'  => $directory_url,
+        ];
+    }
+}
+
+if (!function_exists('blc_collect_report_rows')) {
+    /**
+     * Fetch rows that should be exported for a dataset type.
+     *
+     * @param string $dataset_type Dataset identifier.
+     *
+     * @return array<int, array<string,mixed>>|\WP_Error
+     */
+    function blc_collect_report_rows($dataset_type) {
+        global $wpdb;
+
+        if (!isset($wpdb) || !is_object($wpdb) || !isset($wpdb->prefix)) {
+            return new \WP_Error(
+                'blc_report_database_unavailable',
+                __('The WordPress database layer is unavailable for report exports.', 'liens-morts-detector-jlg')
+            );
+        }
+
+        $row_types = [];
+        if (function_exists('blc_get_dataset_row_types')) {
+            $row_types = blc_get_dataset_row_types($dataset_type);
+        } elseif ($dataset_type === 'image') {
+            $row_types = ['image', 'remote-image'];
+        } else {
+            $row_types = ['link'];
+        }
+
+        if (!is_array($row_types) || $row_types === []) {
+            return [];
+        }
+
+        if (!method_exists($wpdb, 'prepare') || !method_exists($wpdb, 'get_results')) {
+            return new \WP_Error(
+                'blc_report_database_methods_missing',
+                __('The database connection does not support prepared statements required for exports.', 'liens-morts-detector-jlg')
+            );
+        }
+
+        $placeholders = implode(',', array_fill(0, count($row_types), '%s'));
+        $table_name   = $wpdb->prefix . 'blc_broken_links';
+
+        $query = $wpdb->prepare(
+            "SELECT url, http_status, post_id, post_title, type, occurrence_index, is_internal, ignored_at, last_checked_at, redirect_target_url, context_excerpt " .
+            "FROM $table_name WHERE type IN ($placeholders) ORDER BY ignored_at IS NULL DESC, http_status DESC, url ASC",
+            $row_types
+        );
+
+        if (!is_string($query)) {
+            return new \WP_Error(
+                'blc_report_query_prepare_failed',
+                __('Failed to prepare the export query.', 'liens-morts-detector-jlg')
+            );
+        }
+
+        $raw_rows = $wpdb->get_results($query, ARRAY_A);
+        if (!is_array($raw_rows)) {
+            $raw_rows = [];
+        }
+
+        $rows = [];
+        foreach ($raw_rows as $row) {
+            $rows[] = [
+                'url'                => isset($row['url']) ? (string) $row['url'] : '',
+                'http_status'        => isset($row['http_status']) && $row['http_status'] !== null ? (int) $row['http_status'] : null,
+                'post_id'            => isset($row['post_id']) ? (int) $row['post_id'] : 0,
+                'post_title'         => isset($row['post_title']) ? (string) $row['post_title'] : '',
+                'row_type'           => isset($row['type']) ? (string) $row['type'] : '',
+                'occurrence_index'   => isset($row['occurrence_index']) && $row['occurrence_index'] !== null ? (int) $row['occurrence_index'] : null,
+                'is_internal'        => isset($row['is_internal']) ? ((int) $row['is_internal'] === 1) : false,
+                'ignored_at'         => isset($row['ignored_at']) && $row['ignored_at'] !== null ? (string) $row['ignored_at'] : '',
+                'last_checked_at'    => isset($row['last_checked_at']) && $row['last_checked_at'] !== null ? (string) $row['last_checked_at'] : '',
+                'redirect_target_url'=> isset($row['redirect_target_url']) ? (string) $row['redirect_target_url'] : '',
+                'context_excerpt'    => isset($row['context_excerpt']) ? (string) $row['context_excerpt'] : '',
+            ];
+        }
+
+        return $rows;
+    }
+}
+
+if (!function_exists('blc_write_report_export')) {
+    /**
+     * Serialize dataset rows to a CSV file.
+     *
+     * @param string               $dataset_type Dataset identifier.
+     * @param array<int,array>     $rows         Rows returned by {@see blc_collect_report_rows()}.
+     * @param array<string,string> $directory    Export directory information.
+     * @param array<string,mixed>  $status       Latest scan status for the dataset.
+     *
+     * @return array<string,mixed>|\WP_Error
+     */
+    function blc_write_report_export($dataset_type, array $rows, array $directory, array $status) {
+        $timestamp = time();
+        $filename  = sprintf('blc-report-%s-%s.csv', $dataset_type, gmdate('Ymd-His', $timestamp));
+        $file_path = rtrim($directory['path'], '/\\') . '/' . $filename;
+
+        $resource = fopen($file_path, 'wb');
+        if ($resource === false) {
+            return new \WP_Error(
+                'blc_report_export_write_failed',
+                sprintf(
+                    /* translators: %s: file path. */
+                    __('Unable to write the report export file (%s).', 'liens-morts-detector-jlg'),
+                    $file_path
+                )
+            );
+        }
+
+        $headers = [
+            'dataset',
+            'url',
+            'http_status',
+            'post_id',
+            'post_title',
+            'row_type',
+            'occurrence_index',
+            'is_internal',
+            'ignored_at',
+            'last_checked_at',
+            'redirect_target_url',
+            'context_excerpt',
+        ];
+
+        $delimiter = ',';
+        $enclosure = '"';
+        $escape    = '\\';
+
+        fputcsv($resource, $headers, $delimiter, $enclosure, $escape);
+
+        foreach ($rows as $row) {
+            $line = [
+                $dataset_type,
+                isset($row['url']) ? (string) $row['url'] : '',
+                isset($row['http_status']) && $row['http_status'] !== null ? (string) $row['http_status'] : '',
+                isset($row['post_id']) ? (string) (int) $row['post_id'] : '0',
+                isset($row['post_title']) ? (string) $row['post_title'] : '',
+                isset($row['row_type']) ? (string) $row['row_type'] : '',
+                isset($row['occurrence_index']) && $row['occurrence_index'] !== null ? (string) (int) $row['occurrence_index'] : '',
+                !empty($row['is_internal']) ? '1' : '0',
+                isset($row['ignored_at']) ? (string) $row['ignored_at'] : '',
+                isset($row['last_checked_at']) ? (string) $row['last_checked_at'] : '',
+                isset($row['redirect_target_url']) ? (string) $row['redirect_target_url'] : '',
+                isset($row['context_excerpt']) ? (string) $row['context_excerpt'] : '',
+            ];
+
+            fputcsv($resource, $line, $delimiter, $enclosure, $escape);
+        }
+
+        fclose($resource);
+
+        $relative_path = basename($file_path);
+        $file_url = isset($directory['url']) && $directory['url'] !== ''
+            ? rtrim($directory['url'], '/\\') . '/' . $relative_path
+            : '';
+
+        $metadata = [
+            'dataset_type'        => $dataset_type,
+            'file_path'           => $file_path,
+            'relative_path'       => $relative_path,
+            'file_url'            => $file_url,
+            'row_count'           => count($rows),
+            'generated_at'        => $timestamp,
+            'source_state'        => isset($status['state']) ? (string) $status['state'] : '',
+            'source_updated_at'   => isset($status['updated_at']) ? (int) $status['updated_at'] : 0,
+            'source_ended_at'     => isset($status['ended_at']) ? (int) $status['ended_at'] : 0,
+        ];
+
+        if (function_exists('md5_file')) {
+            $checksum = @md5_file($file_path);
+            if ($checksum !== false) {
+                $metadata['checksum_md5'] = $checksum;
+            }
+        }
+
+        if (function_exists('filesize')) {
+            $size = @filesize($file_path);
+            if ($size !== false) {
+                $metadata['filesize'] = (int) $size;
+            }
+        }
+
+        return $metadata;
+    }
+}
+
+if (!function_exists('blc_get_scan_status_for_report_dataset')) {
+    /**
+     * Retrieve the latest scan status for a dataset.
+     *
+     * @param string $dataset_type Dataset identifier.
+     *
+     * @return array<string,mixed>|null
+     */
+    function blc_get_scan_status_for_report_dataset($dataset_type) {
+        if ($dataset_type === 'image') {
+            if (function_exists('blc_get_image_scan_status')) {
+                return blc_get_image_scan_status();
+            }
+
+            return null;
+        }
+
+        if (function_exists('blc_get_link_scan_status')) {
+            return blc_get_link_scan_status();
+        }
+
+        return null;
+    }
+}
+
+if (!function_exists('blc_get_previous_report_export')) {
+    /**
+     * Retrieve metadata of the last generated report for a dataset.
+     *
+     * @param string $dataset_type Dataset identifier.
+     *
+     * @return array<string,mixed>|null
+     */
+    function blc_get_previous_report_export($dataset_type) {
+        $stored = get_option('blc_report_export_status', []);
+        if (!is_array($stored)) {
+            return null;
+        }
+
+        $dataset_type = (string) $dataset_type;
+
+        return isset($stored[$dataset_type]) && is_array($stored[$dataset_type])
+            ? $stored[$dataset_type]
+            : null;
+    }
+}
+
+if (!function_exists('blc_should_generate_report_export')) {
+    /**
+     * Determine whether a new export should be produced for the dataset.
+     *
+     * @param string                     $dataset_type Dataset identifier.
+     * @param array<string,mixed>        $status       Latest scan status.
+     * @param array<string,mixed>|null   $previous     Previously stored metadata.
+     * @param bool                       $force        Whether to bypass freshness checks.
+     *
+     * @return bool
+     */
+    function blc_should_generate_report_export($dataset_type, array $status, ?array $previous, $force) {
+        if ($force) {
+            return true;
+        }
+
+        $state = isset($status['state']) ? (string) $status['state'] : '';
+        if ($state === 'running' || $state === 'queued') {
+            return false;
+        }
+
+        $ended_at   = isset($status['ended_at']) ? (int) $status['ended_at'] : 0;
+        $updated_at = isset($status['updated_at']) ? (int) $status['updated_at'] : 0;
+        $reference  = $ended_at > 0 ? $ended_at : $updated_at;
+
+        if ($previous === null) {
+            return true;
+        }
+
+        $previous_reference = 0;
+        if (isset($previous['source_ended_at'])) {
+            $previous_reference = (int) $previous['source_ended_at'];
+        }
+        if (isset($previous['source_updated_at'])) {
+            $previous_reference = max($previous_reference, (int) $previous['source_updated_at']);
+        }
+
+        if ($reference === 0) {
+            return $previous_reference === 0;
+        }
+
+        return $reference > $previous_reference;
+    }
+}
+
+if (!function_exists('blc_record_report_export_result')) {
+    /**
+     * Persist metadata about the latest export attempt.
+     *
+     * @param string                    $dataset_type Dataset identifier.
+     * @param array<string,mixed>       $status       Latest scan status.
+     * @param array<string,mixed>|null  $metadata     Export metadata on success.
+     * @param bool                      $skipped      Whether the export was skipped.
+     *
+     * @return void
+     */
+    function blc_record_report_export_result($dataset_type, array $status, ?array $metadata, $skipped) {
+        $dataset_type = (string) $dataset_type;
+        $stored = get_option('blc_report_export_status', []);
+        if (!is_array($stored)) {
+            $stored = [];
+        }
+
+        $entry = isset($stored[$dataset_type]) && is_array($stored[$dataset_type])
+            ? $stored[$dataset_type]
+            : [];
+
+        $entry['last_attempted_at'] = time();
+        $entry['source_state']      = isset($status['state']) ? (string) $status['state'] : '';
+        $entry['source_updated_at'] = isset($status['updated_at']) ? (int) $status['updated_at'] : 0;
+        $entry['source_ended_at']   = isset($status['ended_at']) ? (int) $status['ended_at'] : 0;
+        $entry['skipped']           = (bool) $skipped;
+
+        if (!$skipped && is_array($metadata)) {
+            $entry = array_merge($entry, $metadata);
+            $entry['skipped'] = false;
+        }
+
+        $stored[$dataset_type] = $entry;
+
+        update_option('blc_report_export_status', $stored, false);
+    }
+}
+
+if (!function_exists('blc_log_report_export_error')) {
+    /**
+     * Log an export error using WordPress' error_log when available.
+     *
+     * @param \WP_Error $error Error instance.
+     *
+     * @return void
+     */
+    function blc_log_report_export_error($error) {
+        if (!($error instanceof \WP_Error)) {
+            return;
+        }
+
+        $message = $error->get_error_message();
+        if ($message === '') {
+            $message = sprintf('BLC report export error: %s', $error->get_error_code());
+        }
+
+        if (function_exists('error_log')) {
+            error_log('BLC: ' . $message);
+        }
+    }
+}

--- a/liens-morts-detector-jlg/liens-morts-detector-jlg.php
+++ b/liens-morts-detector-jlg/liens-morts-detector-jlg.php
@@ -56,6 +56,7 @@ require_once BLC_PLUGIN_PATH . 'includes/blc-scanner.php';
 require_once BLC_PLUGIN_PATH . 'includes/blc-utils.php';
 require_once BLC_PLUGIN_PATH . 'includes/blc-settings-fields.php';
 require_once BLC_PLUGIN_PATH . 'includes/blc-admin-pages.php';
+require_once BLC_PLUGIN_PATH . 'includes/blc-reports.php';
 require_once BLC_PLUGIN_PATH . 'includes/class-blc-links-list-table.php';
 require_once BLC_PLUGIN_PATH . 'includes/class-blc-images-list-table.php';
 require_once BLC_PLUGIN_PATH . 'includes/blc-cli.php';
@@ -117,6 +118,7 @@ add_action('blc_check_links', 'blc_perform_check');
 add_action('blc_check_batch', 'blc_perform_check', 10, 3);
 add_action('blc_manual_check_batch', 'blc_perform_check', 10, 3);
 add_action('blc_check_image_batch', 'blc_perform_image_check', 10, 2);
+add_action('blc_generate_report_exports', 'blc_run_automated_report_exports');
 
 // Ajoute nos fichiers CSS et JS dans l'administration
 add_action('admin_enqueue_scripts', 'blc_enqueue_admin_assets');

--- a/tests/BlcReportExportsTest.php
+++ b/tests/BlcReportExportsTest.php
@@ -1,0 +1,370 @@
+<?php
+
+namespace {
+    require_once __DIR__ . '/translation-stubs.php';
+
+    if (!class_exists('WP_Error')) {
+        class WP_Error
+        {
+            /** @var string */
+            private $code;
+
+            /** @var string */
+            private $message;
+
+            /** @var mixed */
+            private $data;
+
+            public function __construct($code = '', $message = '', $data = null)
+            {
+                $this->code    = (string) $code;
+                $this->message = (string) $message;
+                $this->data    = $data;
+            }
+
+            public function get_error_code()
+            {
+                return $this->code;
+            }
+
+            public function get_error_message()
+            {
+                return $this->message;
+            }
+
+            public function get_error_data()
+            {
+                return $this->data;
+            }
+        }
+    }
+
+    if (!function_exists('is_wp_error')) {
+        function is_wp_error($thing)
+        {
+            return $thing instanceof \WP_Error;
+        }
+    }
+
+    if (!defined('HOUR_IN_SECONDS')) {
+        define('HOUR_IN_SECONDS', 3600);
+    }
+
+    if (!defined('MINUTE_IN_SECONDS')) {
+        define('MINUTE_IN_SECONDS', 60);
+    }
+
+    if (!defined('DAY_IN_SECONDS')) {
+        define('DAY_IN_SECONDS', 86400);
+    }
+
+    if (!defined('ARRAY_A')) {
+        define('ARRAY_A', 'ARRAY_A');
+    }
+
+    if (!isset($GLOBALS['blc_report_test_link_status'])) {
+        $GLOBALS['blc_report_test_link_status'] = [
+            'state'      => 'idle',
+            'ended_at'   => 0,
+            'updated_at' => 0,
+        ];
+    }
+
+    if (!function_exists('blc_get_link_scan_status')) {
+        function blc_get_link_scan_status()
+        {
+            return is_array($GLOBALS['blc_report_test_link_status'])
+                ? $GLOBALS['blc_report_test_link_status']
+                : [
+                    'state'      => 'idle',
+                    'ended_at'   => 0,
+                    'updated_at' => 0,
+                ];
+        }
+    }
+}
+
+namespace Tests {
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class BlcReportExportsTest extends TestCase
+{
+    /**
+     * @var array<string,mixed>
+     */
+    private array $options = [];
+
+    /**
+     * @var array<int,array{timestamp:int, schedule:string, hook:string}>
+     */
+    private array $scheduledEvents = [];
+
+    /**
+     * @var array<int,string>
+     */
+    private array $clearedHooks = [];
+
+    /**
+     * @var array<int,string>
+     */
+    private array $errorLogs = [];
+
+    /**
+     * @var string
+     */
+    private string $uploadsDir;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        require_once __DIR__ . '/../vendor/autoload.php';
+        Monkey\setUp();
+
+        if (!defined('ABSPATH')) {
+            define('ABSPATH', __DIR__ . '/../');
+        }
+
+        $this->options = [];
+        $this->scheduledEvents = [];
+        $this->clearedHooks = [];
+        $this->errorLogs = [];
+        $this->uploadsDir = sys_get_temp_dir() . '/blc-report-tests-' . uniqid();
+
+        Functions\when('apply_filters')->alias(static fn($hook, $value) => $value);
+        Functions\when('sanitize_key')->alias(static function ($value) {
+            $value = strtolower(is_scalar($value) ? (string) $value : '');
+
+            return preg_replace('/[^a-z0-9_\-]/', '', $value);
+        });
+
+        $test = $this;
+
+        Functions\when('get_option')->alias(static function ($name, $default = false) use ($test) {
+            return $test->options[$name] ?? $default;
+        });
+
+        Functions\when('update_option')->alias(static function ($name, $value) use ($test) {
+            $test->options[$name] = $value;
+
+            return true;
+        });
+
+        Functions\when('add_option')->alias(static function ($name, $value) use ($test) {
+            if (!array_key_exists($name, $test->options)) {
+                $test->options[$name] = $value;
+            }
+
+            return true;
+        });
+
+        Functions\when('wp_get_schedules')->alias(static function () {
+            return [
+                'hourly' => [
+                    'interval' => HOUR_IN_SECONDS,
+                    'display'  => 'Hourly',
+                ],
+                'daily' => [
+                    'interval' => DAY_IN_SECONDS,
+                    'display'  => 'Daily',
+                ],
+            ];
+        });
+
+        Functions\when('wp_schedule_event')->alias(function ($timestamp, $schedule, $hook) use ($test) {
+            $test->scheduledEvents[] = [
+                'timestamp' => (int) $timestamp,
+                'schedule'  => (string) $schedule,
+                'hook'      => (string) $hook,
+            ];
+
+            return true;
+        });
+
+        Functions\when('wp_next_scheduled')->alias(static fn($hook) => false);
+
+        Functions\when('wp_clear_scheduled_hook')->alias(function ($hook) use ($test) {
+            $test->clearedHooks[] = (string) $hook;
+
+            return true;
+        });
+
+        Functions\when('error_log')->alias(function ($message) use ($test) {
+            $test->errorLogs[] = (string) $message;
+
+            return true;
+        });
+
+        Functions\when('wp_upload_dir')->alias(function () use ($test) {
+            return [
+                'basedir' => $test->uploadsDir,
+                'baseurl' => 'https://example.com/uploads',
+                'error'   => false,
+            ];
+        });
+
+        Functions\when('wp_mkdir_p')->alias(static function ($dir) {
+            if (is_dir($dir)) {
+                return true;
+            }
+
+            return mkdir($dir, 0777, true);
+        });
+
+        Functions\when('time')->alias(static function () {
+            return 1700000000;
+        });
+
+        require_once __DIR__ . '/../liens-morts-detector-jlg/includes/blc-cron.php';
+        require_once __DIR__ . '/../liens-morts-detector-jlg/includes/blc-reports.php';
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->uploadsDir)) {
+            $iterator = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($this->uploadsDir, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST
+            );
+
+            foreach ($iterator as $fileInfo) {
+                if ($fileInfo->isFile()) {
+                    @unlink($fileInfo->getPathname());
+                } else {
+                    @rmdir($fileInfo->getPathname());
+                }
+            }
+
+            @rmdir($this->uploadsDir);
+        }
+
+        Monkey\tearDown();
+        parent::tearDown();
+    }
+
+    public function test_sync_schedule_schedules_event_when_enabled(): void
+    {
+        $this->options['blc_report_export_enabled'] = true;
+        Functions\when('wp_next_scheduled')->alias(static fn($hook) => false);
+
+        \blc_sync_report_export_schedule();
+
+        $this->assertNotEmpty($this->scheduledEvents, 'The report export event should be scheduled when enabled.');
+        $this->assertSame('blc_generate_report_exports', $this->scheduledEvents[0]['hook']);
+    }
+
+    public function test_sync_schedule_clears_event_when_disabled(): void
+    {
+        $this->options['blc_report_export_enabled'] = false;
+        Functions\when('wp_next_scheduled')->alias(static fn($hook) => 1234567890);
+
+        \blc_sync_report_export_schedule();
+
+        $this->assertContains('blc_generate_report_exports', $this->clearedHooks);
+    }
+
+    public function test_run_exports_creates_csv_for_completed_scan(): void
+    {
+        $this->options['blc_report_export_enabled'] = true;
+        $this->options['blc_report_export_frequency'] = 'daily';
+        $this->options['blc_report_export_status'] = [];
+
+        $GLOBALS['blc_report_test_link_status'] = [
+            'state'      => 'completed',
+            'ended_at'   => 1700000000,
+            'updated_at' => 1700000000,
+        ];
+
+        global $wpdb;
+        $rows = [
+            [
+                'url' => 'https://example.com/broken',
+                'http_status' => 404,
+                'post_id' => 12,
+                'post_title' => 'Broken Link',
+                'type' => 'link',
+                'occurrence_index' => 0,
+                'is_internal' => 1,
+                'ignored_at' => null,
+                'last_checked_at' => '2024-01-01 10:00:00',
+                'redirect_target_url' => '',
+                'context_excerpt' => 'Sample excerpt',
+            ],
+        ];
+
+        $wpdb = new class($rows) {
+            public $prefix = 'wp_';
+
+            /** @var array<int,array<string,mixed>> */
+            private array $rows;
+
+            public function __construct(array $rows)
+            {
+                $this->rows = $rows;
+            }
+
+            public function prepare($query, $args = null)
+            {
+                if ($args === null) {
+                    return $query;
+                }
+
+                if (!is_array($args)) {
+                    $args = array_slice(func_get_args(), 1);
+                }
+
+                foreach ($args as $value) {
+                    $query = preg_replace('/%s/', "'" . addslashes((string) $value) . "'", $query, 1);
+                }
+
+                return $query;
+            }
+
+            public function get_results($query, $output = ARRAY_A)
+            {
+                if ($output !== ARRAY_A) {
+                    return [];
+                }
+
+                return $this->rows;
+            }
+        };
+
+        \blc_run_automated_report_exports();
+
+        $exportDir = $this->uploadsDir . '/blc-report-exports';
+        $files = is_dir($exportDir) ? array_values(array_diff(scandir($exportDir) ?: [], ['.', '..'])) : [];
+
+        $this->assertNotEmpty($files, 'The report export directory should contain a CSV file.');
+
+        $status = $this->options['blc_report_export_status']['link'] ?? [];
+        $this->assertNotEmpty($status, 'Export metadata should be stored.');
+        $this->assertSame(1, $status['row_count']);
+        $this->assertSame('blc-report-link-20231114-221320.csv', $status['relative_path']);
+        $this->assertFalse($status['skipped']);
+    }
+
+    public function test_run_exports_skips_when_scan_not_completed(): void
+    {
+        $this->options['blc_report_export_enabled'] = true;
+        $this->options['blc_report_export_status'] = [];
+
+        $GLOBALS['blc_report_test_link_status'] = [
+            'state'      => 'running',
+            'ended_at'   => 0,
+            'updated_at' => 1700000000,
+        ];
+
+        \blc_run_automated_report_exports();
+
+        $status = $this->options['blc_report_export_status']['link'] ?? null;
+        $this->assertNotNull($status, 'A skipped attempt should still be recorded.');
+        $this->assertTrue($status['skipped']);
+        $this->assertArrayNotHasKey('file_path', $status);
+    }
+}
+
+}


### PR DESCRIPTION
## Summary
- add a dedicated report export service that writes scan results to CSV and stores metadata
- schedule the new export cron job during activation, clear it on deactivation and document the roadmap progress
- cover the scheduler behaviour with a PHPUnit suite exercising scheduling, generation and skip logic

## Testing
- vendor/bin/phpunit tests/BlcReportExportsTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e5762180ec832e8ce5b28869bcdc4a