### PR TITLE
Surface top broken-link domains on the dashboard

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -208,6 +208,91 @@
     }
 }
 
+.blc-top-domains {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.blc-top-domains__title {
+    margin: 0;
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--blc-admin-text);
+}
+
+.blc-top-domains__description {
+    margin: 0;
+    color: var(--blc-admin-text-subtle);
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
+
+.blc-top-domains__list {
+    margin: 0;
+    padding-left: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
+.blc-top-domains__item {
+    position: relative;
+    padding-left: 4px;
+}
+
+.blc-top-domains__header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 8px;
+}
+
+.blc-top-domains__host {
+    font-weight: 600;
+    color: var(--blc-admin-text);
+}
+
+.blc-top-domains__count {
+    font-size: 0.95rem;
+    color: var(--blc-admin-text-subtle);
+}
+
+.blc-top-domains__breakdown {
+    display: block;
+    margin-top: 2px;
+    font-size: 0.9rem;
+    color: var(--blc-admin-text-subtle);
+}
+
+.blc-top-domains__link {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 6px;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--blc-admin-accent);
+    text-decoration: none;
+    transition: color var(--blc-admin-transition);
+}
+
+.blc-top-domains__link::after {
+    content: '\2192';
+    font-size: 0.9em;
+    transition: transform var(--blc-admin-transition);
+}
+
+.blc-top-domains__link:hover,
+.blc-top-domains__link:focus-visible {
+    color: var(--blc-admin-accent-strong);
+}
+
+.blc-top-domains__link:hover::after,
+.blc-top-domains__link:focus-visible::after {
+    transform: translateX(4px);
+}
+
 .wrap form p small {
     color: var(--blc-admin-text-subtle);
 }

--- a/tests/translation-stubs.php
+++ b/tests/translation-stubs.php
@@ -16,10 +16,10 @@ if (!function_exists('__')) {
     }
 }
 
-if (!function_exists('esc_html__')) {
-    function esc_html__($text, $domain = null)
+if (!function_exists('_n')) {
+    function _n($single, $plural, $number, $domain = null)
     {
-        return $text;
+        return ((int) $number === 1) ? $single : $plural;
     }
 }
 
@@ -54,14 +54,28 @@ if (!function_exists('esc_attr_e')) {
 if (!function_exists('esc_textarea')) {
     function esc_textarea($text)
     {
-        return $text;
+        return htmlspecialchars((string) $text, ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
     }
 }
 
 if (!function_exists('esc_html')) {
     function esc_html($text)
     {
-        return $text;
+        return htmlspecialchars((string) $text, ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+}
+
+if (!function_exists('esc_html__')) {
+    function esc_html__($text, $domain = null)
+    {
+        return esc_html($text);
+    }
+}
+
+if (!function_exists('sanitize_html_class')) {
+    function sanitize_html_class($class)
+    {
+        return is_scalar($class) ? (string) $class : '';
     }
 }
 
@@ -69,6 +83,13 @@ if (!function_exists('esc_url')) {
     function esc_url($text)
     {
         return $text;
+    }
+}
+
+if (!function_exists('wp_parse_args')) {
+    function wp_parse_args($args, $defaults = [])
+    {
+        return array_merge($defaults, is_array($args) ? $args : (array) $args);
     }
 }
 


### PR DESCRIPTION
## Summary
- add a helper that aggregates broken links by domain and expose the results on the dashboard
- style and render a new insights card that highlights the most impacted domains with quick filters
- update dashboard tests and translation stubs to cover the new reporting section

## Testing
- vendor/bin/phpunit tests/BlcDashboardLinksPageTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e59b4bad20832e82e043f5b65b635e