### PR TITLE
Add fallbacks for admin tabs styles and tests

### DIFF
--- a/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
+++ b/liens-morts-detector-jlg/assets/css/blc-admin-styles.css
@@ -34,8 +34,20 @@
     font-family: var(--blc-admin-font-family);
     --blc-admin-accent: var(--wp-admin-theme-color, #6e56cf);
     --blc-admin-accent-strong: var(--wp-admin-theme-color-darker-20, #5746af);
-    --blc-admin-accent-soft: color-mix(in srgb, var(--blc-admin-accent) 15%, #f6f1ff);
-    --blc-admin-accent-muted: color-mix(in srgb, var(--blc-admin-accent) 35%, #f6f1ff);
+    --blc-admin-accent-soft: #f3f0ff;
+    --blc-admin-accent-muted: #e8e4ff;
+}
+
+@supports (color: color-mix(in srgb, white 50%, black)) {
+    :root {
+        --blc-admin-accent-soft: color-mix(in srgb, var(--blc-admin-accent) 15%, #f6f1ff);
+        --blc-admin-accent-muted: color-mix(in srgb, var(--blc-admin-accent) 35%, #f6f1ff);
+    }
+
+    .wp-admin {
+        --blc-admin-accent-soft: color-mix(in srgb, var(--blc-admin-accent) 15%, #f6f1ff);
+        --blc-admin-accent-muted: color-mix(in srgb, var(--blc-admin-accent) 35%, #f6f1ff);
+    }
 }
 
 @media (prefers-color-scheme: dark) {

--- a/tests/BlcAdminNavigationTest.php
+++ b/tests/BlcAdminNavigationTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace {
+    require_once __DIR__ . '/translation-stubs.php';
+
+    if (!defined('ABSPATH')) {
+        define('ABSPATH', __DIR__ . '/../');
+    }
+}
+
+namespace Tests {
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use PHPUnit\Framework\TestCase;
+
+class BlcAdminNavigationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        require_once __DIR__ . '/../vendor/autoload.php';
+
+        Monkey\setUp();
+
+        Functions\when('admin_url')->alias(static function ($path = '') {
+            $path = (string) $path;
+
+            return 'admin.php?page=' . preg_replace('/^admin\.php\?page=/', '', $path);
+        });
+
+        Functions\when('add_query_arg')->alias(static function ($key, $value, $url) {
+            $separator = (false === strpos($url, '?')) ? '?' : '&';
+
+            return $url . $separator . rawurlencode((string) $key) . '=' . rawurlencode((string) $value);
+        });
+
+        require_once __DIR__ . '/../liens-morts-detector-jlg/includes/blc-admin-pages.php';
+    }
+
+    protected function tearDown(): void
+    {
+        Monkey\tearDown();
+
+        parent::tearDown();
+    }
+
+    public function test_navigation_has_accessible_label_and_active_link(): void
+    {
+        ob_start();
+        blc_render_dashboard_tabs('links');
+        $html = (string) ob_get_clean();
+
+        $this->assertNotSame('', $html, 'Expected navigation markup to be rendered.');
+        $this->assertStringContainsString('<nav class="blc-admin-tabs"', $html);
+        $this->assertStringContainsString('aria-label="Navigation du tableau de bord Liens Morts"', $html);
+        $this->assertSame(1, substr_count($html, 'aria-current="page"'));
+        $this->assertStringContainsString('href="admin.php?page=blc-dashboard"', $html);
+        $this->assertStringContainsString('class="blc-admin-tabs__link is-active"', $html);
+    }
+
+    public function test_navigation_marks_requested_tab_as_current(): void
+    {
+        ob_start();
+        blc_render_dashboard_tabs('history');
+        $html = (string) ob_get_clean();
+
+        $this->assertSame(1, substr_count($html, 'aria-current="page"'));
+        $this->assertStringContainsString('href="admin.php?page=blc-history" aria-current="page"', $html);
+        $this->assertStringNotContainsString('href="admin.php?page=blc-dashboard" aria-current="page"', $html);
+        $this->assertStringContainsString('class="blc-admin-tabs__link is-active" href="admin.php?page=blc-history"', $html);
+    }
+}
+
+}


### PR DESCRIPTION
## Summary
- provide graceful fallbacks for admin accent colors when `color-mix` is unavailable and gate the modern values behind a feature check
- add PHPUnit coverage that asserts the dashboard tab navigation exposes accessible labels and `aria-current` markers

## Testing
- npm test
- ./vendor/bin/phpunit tests/BlcAdminNavigationTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e64f4e5e60832e881817733e5b41c9