### PR TITLE
Fix manual scan scheduling timestamps

### DIFF
--- a/liens-morts-detector-jlg/includes/blc-admin-pages.php
+++ b/liens-morts-detector-jlg/includes/blc-admin-pages.php
@@ -278,6 +278,7 @@ function blc_schedule_manual_link_scan($is_full_scan = false) {
             'total_items'       => 0,
             'processed_items'   => 0,
             'is_full_scan'      => $is_full_scan,
+            'started_at'        => 0,
             'job_id'            => $job_id,
             'attempt'           => $attempt,
         ]);
@@ -355,7 +356,7 @@ function blc_schedule_manual_link_scan($is_full_scan = false) {
         'is_full_scan'      => $is_full_scan,
         'message'           => $status_message,
         'last_error'        => '',
-        'started_at'        => time(),
+        'started_at'        => 0,
         'ended_at'          => 0,
         'job_id'            => $job_id,
         'attempt'           => $attempt,
@@ -396,6 +397,7 @@ function blc_schedule_manual_image_scan() {
             'state'      => 'failed',
             'message'    => $failure_message,
             'last_error' => $failure_message,
+            'started_at' => 0,
         ]);
 
         return [
@@ -447,7 +449,7 @@ function blc_schedule_manual_image_scan() {
         'is_full_scan'      => true,
         'message'           => $status_message,
         'last_error'        => '',
-        'started_at'        => time(),
+        'started_at'        => 0,
         'ended_at'          => 0,
     ]);
 

--- a/liens-morts-detector-jlg/includes/blc-scanner.php
+++ b/liens-morts-detector-jlg/includes/blc-scanner.php
@@ -217,7 +217,7 @@ if (!function_exists('blc_get_link_scan_transition_rules')) {
      */
     function blc_get_link_scan_transition_rules() {
         return [
-            'idle'      => ['idle', 'queued', 'running'],
+            'idle'      => ['idle', 'queued', 'running', 'failed'],
             'queued'    => ['queued', 'running', 'cancelled', 'failed', 'idle'],
             'running'   => ['running', 'completed', 'failed', 'cancelled', 'idle'],
             'completed' => ['completed', 'idle', 'queued'],

--- a/tests/BlcManualScanSchedulingTest.php
+++ b/tests/BlcManualScanSchedulingTest.php
@@ -178,6 +178,8 @@ class BlcManualScanSchedulingTest extends TestCase
         $this->assertSame('failed', $status['state']);
         $this->assertTrue($status['is_full_scan']);
         $this->assertSame($status['message'], $result['message']);
+        $this->assertSame(0, $status['started_at']);
+        $this->assertGreaterThan(0, $status['ended_at']);
 
         $this->assertSame('blc_manual_check_schedule_failed', $this->dispatchedActions[0]['hook']);
         $this->assertSame([true, true], $this->dispatchedActions[0]['args']);
@@ -201,6 +203,8 @@ class BlcManualScanSchedulingTest extends TestCase
         $this->assertFalse($status['is_full_scan']);
         $this->assertStringContainsString('Analyse programmée.', $status['message']);
         $this->assertStringContainsString("La vérification des liens a été programmée", $result['message']);
+        $this->assertSame(0, $status['started_at']);
+        $this->assertSame(0, $status['ended_at']);
     }
 
     public function test_it_marks_manual_trigger_failure_when_spawn_cron_returns_false(): void
@@ -221,6 +225,8 @@ class BlcManualScanSchedulingTest extends TestCase
         $this->assertStringContainsString('Analyse programmée.', $status['message']);
         $this->assertStringContainsString('Le déclenchement immédiat du cron a échoué.', $status['message']);
         $this->assertStringContainsString("La vérification des liens a été programmée", $result['message']);
+        $this->assertSame(0, $status['started_at']);
+        $this->assertSame(0, $status['ended_at']);
     }
 }
 }

--- a/tests/translation-stubs.php
+++ b/tests/translation-stubs.php
@@ -1,5 +1,9 @@
 <?php
 
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/../');
+}
+
 if (!function_exists('__')) {
     function __($text, $domain = null)
     {


### PR DESCRIPTION
## Summary
- reset manual link and image scan timestamps when jobs are only queued so dashboards show accurate runtimes
- allow idle→failed transitions for manual scan attempts and extend scheduling tests to assert the timestamp reset
- define ABSPATH in the shared test stubs so the plugin files can be loaded in isolation during PHPUnit runs

## Testing
- vendor/bin/phpunit tests/BlcManualScanSchedulingTest.php
- vendor/bin/phpunit tests/LinkScanStatusTest.php

------
https://chatgpt.com/codex/tasks/task_e_68e670089684832e90d8ca7ce74ee780